### PR TITLE
Add `expanded` class to wrapper div when flags are being displayed

### DIFF
--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -972,6 +972,10 @@ class IntlTelInputApp extends Component {
     let wrapperClass = this.props.css[0],
         inputClass = this.props.css[1];
 
+    if (intlTelInputData.countryList.showDropdown) {
+      wrapperClass += ' expanded';
+    }
+
     return (
       <div className={wrapperClass}>
         <FlagDropDown ref="flagDropDown"


### PR DESCRIPTION
- Having a common class on the wrapper div allows styling to
be defined for both `div.flag-dropdown` and the `input` field
when the dropdown is expanded
- More info https://github.com/jackocnr/intl-tel-input/pull/203