### PR TITLE
Allow countries dropdown data to be configurable through `countriesData` prop

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -141,6 +141,11 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Value.</td>
               </tr>
               <tr>
+                <th scope="row">countriesData</th>
+                <td><code>array</code></td>
+                <td>Countries data can be configured, it defaults to data defined in `AllCountries`.</td>
+              </tr>
+              <tr>
                 <th scope="row">defaultValue</th>
                 <td><code>''</code></td>
                 <td>Default value.</td>

--- a/src/components/AllCountries.js
+++ b/src/components/AllCountries.js
@@ -1311,8 +1311,8 @@ const defaultCountriesData = [
 
 let countries;
 
-function _formatCountriesData(countries) {
-  return countries.map((country) => ({
+function _formatCountriesData(countriesData) {
+  return countriesData.map((country) => ({
     name: country[0],
     iso2: country[1],
     dialCode: country[2],
@@ -1335,7 +1335,7 @@ function getCountries() {
 
 const AllCountries = {
   initialize,
-  getCountries
+  getCountries,
 };
 
 export default AllCountries;

--- a/src/components/AllCountries.js
+++ b/src/components/AllCountries.js
@@ -61,7 +61,8 @@ JSON.stringify(result);
 //    Order (if >1 country with same dial code),
 //    Area codes (if >1 country with same dial code)
 // ]
-const allCountries = [
+
+const defaultCountriesData = [
   [
     'Afghanistan (‫افغانستان‬‎)',
     'af',
@@ -1308,13 +1309,33 @@ const allCountries = [
   ],
 ];
 
-// loop over all of the countries above
-const result = allCountries.map((country) => ({
-  name: country[0],
-  iso2: country[1],
-  dialCode: country[2],
-  priority: country[3] || 0,
-  areaCodes: country[4] || null,
-}));
+let countries;
 
-export default result;
+function _formatCountriesData(countries) {
+  return countries.map((country) => ({
+    name: country[0],
+    iso2: country[1],
+    dialCode: country[2],
+    priority: country[3] || 0,
+    areaCodes: country[4] || null,
+  }));
+}
+
+function initialize(externalCountriesList) {
+  countries = _formatCountriesData(externalCountriesList || defaultCountriesData);
+}
+
+function getCountries() {
+  if (!countries) {
+    initialize();
+  }
+
+  return countries;
+}
+
+const AllCountries = {
+  initialize,
+  getCountries
+};
+
+export default AllCountries;

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -140,9 +140,6 @@ export default {
 
     if (typeof errorHandler === 'function') {
       errorHandler(countryCode);
-    } else if (countryCode !== 'auto') {
-      // Do not crash, but let user know there is a problem and why
-      console.error(`No country data for "${countryCode}", defaulting to first country`);
     }
 
     return {};

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -140,12 +140,9 @@ export default {
 
     if (typeof errorHandler === 'function') {
       errorHandler(countryCode);
-    } else {
-      if (countryCode === 'auto') {
-        return {};
-      }
-
-      throw new Error(`No country data for "${countryCode}"`);
+    } else if (countryCode !== 'auto') {
+      // Do not crash, but let user know there is a problem and why
+      console.error(`No country data for "${countryCode}", defaulting to first country`);
     }
 
     return {};

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -127,7 +127,7 @@ export default {
 
   // find the country data for the given country code
   getCountryData(countryCode, allowFail, errorHandler) {
-    const countryList = AllCountries;
+    const countryList = AllCountries.getCountries();
     for (let i = 0, max = countryList.length; i < max; i++) {
       if (countryList[i].iso2 === countryCode) {
         return countryList[i];

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -12,6 +12,7 @@ class IntlTelInput extends Component {
   static propTypes = {
     css: PropTypes.arrayOf(PropTypes.string),
     fieldName: PropTypes.string,
+    countriesData: PropTypes.arrayOf(PropTypes.array),
     value: PropTypes.string,
     defaultValue: PropTypes.string,
     disabled: PropTypes.bool,

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -35,6 +35,7 @@ class IntlTelInput extends Component {
     return (
       <Provider store={store}>
         <IntlTelInputApp value={this.props.value}
+          countriesData={this.props.countriesData}
           defaultValue={this.props.defaultValue}
           disabled={this.props.disabled}
           onPhoneNumberChange={this.props.onPhoneNumberChange}

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -117,7 +117,18 @@ class IntlTelInputApp extends Component {
     this.handleUpDownKey = this.handleUpDownKey.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
 
-    this.tempCountry = this.props.defaultCountry;
+    this.tempCountry = this.getTempCountry(this.props.defaultCountry);
+  }
+
+  getTempCountry(countryCode) {
+    let countryData = utils.getCountryData(countryCode);
+
+    // check if country is available in the list
+    if (!countryData.iso2) {
+      countryData = AllCountries.getCountries()[0];
+    }
+
+    return countryData.iso2;
   }
 
   componentDidMount() {
@@ -390,7 +401,6 @@ class IntlTelInputApp extends Component {
   // set the initial state of the input value and the selected flag
   setInitialState() {
     const val = this.props.defaultValue || '';
-    const defaultCountryData = utils.getCountryData(this.props.defaultCountry);
 
     // Init the flag setting
     this.selectFlag(this.props.defaultCountry || '', false);
@@ -400,10 +410,9 @@ class IntlTelInputApp extends Component {
     if (this.getDialCode(val)) {
       this.updateFlagFromNumber(val);
     } else if (this.tempCountry !== 'auto') {
-      // check the defaultCountry option and make sure it's available,
-      // else fall back to the first in the list
+      // check the defaultCountry option, else fall back to the first in the list
       let defaultCountry = this.tempCountry;
-      if (!this.tempCountry || !defaultCountryData.iso2) {
+      if (!this.tempCountry) {
         defaultCountry = (this.preferredCountries.length) ?
           this.preferredCountries[0].iso2 : this.countries[0].iso2;
       }

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -16,6 +16,9 @@ class IntlTelInputApp extends Component {
     css: ['intl-tel-input', ''],
     fieldName: '',
     value: '',
+    // define the countries that'll be present in the dropdown
+    // defaults to the data defined in `AllCountries`
+    countriesData: null,
     // typing digits after a valid number will be added to the extension part of the number
     allowExtensions: false,
     // automatically format the number according to the selected country
@@ -46,6 +49,7 @@ class IntlTelInputApp extends Component {
     css: PropTypes.arrayOf(PropTypes.string),
     fieldName: PropTypes.string,
     value: PropTypes.string,
+    countriesData: PropTypes.arrayOf(PropTypes.array),
     defaultValue: PropTypes.string,
     allowExtensions: PropTypes.bool,
     autoFormat: PropTypes.bool,
@@ -231,10 +235,10 @@ class IntlTelInputApp extends Component {
     // process onlyCountries option
     if (this.props.onlyCountries.length) {
       // build instance country array
-      this.countries = AllCountries.filter((country) =>
+      this.countries = AllCountries.getCountries().filter((country) =>
         this.props.onlyCountries.indexOf(country.iso2) > -1, this);
     } else {
-      this.countries = AllCountries;
+      this.countries = AllCountries.getCountries();
     }
 
     // generate countryCodes map
@@ -599,6 +603,10 @@ class IntlTelInputApp extends Component {
 
   // prepare all of the country data, including onlyCountries and preferredCountries options
   processCountryData() {
+    // format countries data to what is necessary for component function
+    // defaults to data defined in `AllCountries`
+    AllCountries.initialize(this.props.countriesData);
+
     // set the instances country data objects
     this.setInstanceCountryData.call(this);
 

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -120,17 +120,6 @@ class IntlTelInputApp extends Component {
     this.tempCountry = this.getTempCountry(this.props.defaultCountry);
   }
 
-  getTempCountry(countryCode) {
-    let countryData = utils.getCountryData(countryCode);
-
-    // check if country is available in the list
-    if (!countryData.iso2) {
-      countryData = AllCountries.getCountries()[0];
-    }
-
-    return countryData.iso2;
-  }
-
   componentDidMount() {
     window.onload = () => {
       this.windowLoaded = true;
@@ -175,6 +164,17 @@ class IntlTelInputApp extends Component {
     if (this.props.intlTelInputData.telInput.value !== nextProps.intlTelInputData.telInput.value) {
       this.notifyPhoneNumberChange(nextProps.intlTelInputData.telInput.value);
     }
+  }
+
+  getTempCountry(countryCode) {
+    let countryData = utils.getCountryData(countryCode);
+
+    // check if country is available in the list
+    if (!countryData.iso2) {
+      countryData = AllCountries.getCountries()[0];
+    }
+
+    return countryData.iso2;
   }
 
   // set the input value and update the flag

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -390,6 +390,7 @@ class IntlTelInputApp extends Component {
   // set the initial state of the input value and the selected flag
   setInitialState() {
     const val = this.props.defaultValue || '';
+    const defaultCountryData = utils.getCountryData(this.props.defaultCountry);
 
     // Init the flag setting
     this.selectFlag(this.props.defaultCountry || '', false);
@@ -399,9 +400,10 @@ class IntlTelInputApp extends Component {
     if (this.getDialCode(val)) {
       this.updateFlagFromNumber(val);
     } else if (this.tempCountry !== 'auto') {
-      // check the defaultCountry option, else fall back to the first in the list
+      // check the defaultCountry option and make sure it's available,
+      // else fall back to the first in the list
       let defaultCountry = this.tempCountry;
-      if (!this.tempCountry) {
+      if (!this.tempCountry || !defaultCountryData.iso2) {
         defaultCountry = (this.preferredCountries.length) ?
           this.preferredCountries[0].iso2 : this.countries[0].iso2;
       }

--- a/src/index.html
+++ b/src/index.html
@@ -141,6 +141,11 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Value.</td>
               </tr>
               <tr>
+                <th scope="row">countriesData</th>
+                <td><code>array</code></td>
+                <td>Countries data can be configured, it defaults to data defined in `AllCountries`.</td>
+              </tr>
+              <tr>
                 <th scope="row">defaultValue</th>
                 <td><code>''</code></td>
                 <td>Default value.</td>


### PR DESCRIPTION
- [NOT A REQUIRED PROP] Automatically defaults to data defined in `AllCountries.js`
- Create a country singleton in `AllCountries` so data is processed once, but might take external data now
- Initialize `AllCountries` in `processCountryData` method (so before anything happens)
- `AllCountries` now needs to be referenced as `AllCountries.getCountries()` - update references

*PS:* I know you closed issue #68 but please note that the component still works exactly the same way as before, but it's now possible to configure the data that is displayed