### PR TITLE
Remove feature that defaults to country when the field is empty and backspace is pressed

### DIFF
--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -499,9 +499,6 @@ class IntlTelInputApp extends Component {
       // Note: use getNumeric here because the number has not been formatted yet,
       // so could contain bad shit
       countryCode = '';
-    } else if (!number || number === '+') {
-      // empty, or just a plus, so default
-      countryCode = this.tempCountry;
     }
 
     if (countryCode !== null && countryCode !== '' &&


### PR DESCRIPTION
- It's a weird experience and I would argue that it should be removed, but in case I'm missing something and it's important, I sent another PR making is configurable