### PR TITLE
Add `fieldId` config just like `fieldName` exists now

### DIFF
--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -20,7 +20,7 @@ class TelInput extends Component {
         disabled={this.props.disabled ? 'disabled' : false}
         readOnly={this.props.readonly ? 'readonly' : false}
         name={this.props.fieldName}
-        name={this.props.fieldId}
+        id={this.props.fieldId}
         value={this.props.value}
         onChange={this.props.handleInputChange}
         onKeyPress={this.props.handleKeyPress}

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -6,6 +6,7 @@ class TelInput extends Component {
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
     fieldName: PropTypes.string,
+    fieldId: PropTypes.string,
     value: PropTypes.string,
     handleInputChange: PropTypes.func,
     handleKeyPress: PropTypes.func,
@@ -19,6 +20,7 @@ class TelInput extends Component {
         disabled={this.props.disabled ? 'disabled' : false}
         readOnly={this.props.readonly ? 'readonly' : false}
         name={this.props.fieldName}
+        name={this.props.fieldId}
         value={this.props.value}
         onChange={this.props.handleInputChange}
         onKeyPress={this.props.handleKeyPress}

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -11,6 +11,7 @@ export default class IntlTelInputApp extends Component {
   static defaultProps = {
     css: ['intl-tel-input', ''],
     fieldName: '',
+    fieldId: '',
     value: '',
     // define the countries that'll be present in the dropdown
     // defaults to the data defined in `AllCountries`
@@ -47,6 +48,7 @@ export default class IntlTelInputApp extends Component {
   static propTypes = {
     css: PropTypes.arrayOf(PropTypes.string),
     fieldName: PropTypes.string,
+    fieldId: PropTypes.string,
     value: PropTypes.string,
     countriesData: PropTypes.arrayOf(PropTypes.array),
     allowExtensions: PropTypes.bool,
@@ -1145,6 +1147,7 @@ export default class IntlTelInputApp extends Component {
           disabled={this.state.telInput.disabled}
           readonly={this.state.telInput.readonly}
           fieldName={this.props.fieldName}
+          fieldId={this.props.fieldId}
           value={this.state.telInput.value}
         />
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -141,6 +141,16 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Value.</td>
               </tr>
               <tr>
+                <th scope="row">fieldName</th>
+                <td><code>''</code></td>
+                <td>It's used as `input` field `name` attribute.</td>
+              </tr>
+              <tr>
+                <th scope="row">fieldId</th>
+                <td><code>''</code></td>
+                <td>It's used as `input` field `id` attribute.</td>
+              </tr>
+              <tr>
                 <th scope="row">countriesData</th>
                 <td><code>array</code></td>
                 <td>Countries data can be configured, it defaults to data defined in `AllCountries`.</td>

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import fs from 'fs';
 import { assert } from 'chai';
 
-describe.only('TelInput', () => {
+describe('TelInput', () => {
   let renderedComponent;
   let inputComponent;
   let libphonenumberUtils;

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import fs from 'fs';
 import { assert } from 'chai';
 
-describe('TelInput', () => {
+describe.only('TelInput', () => {
   let renderedComponent;
   let inputComponent;
   let libphonenumberUtils;
@@ -26,6 +26,7 @@ describe('TelInput', () => {
     renderedComponent = ReactTestUtils.renderIntoDocument(
       <IntlTelInput css={['intl-tel-input', 'form-control phoneNumber']}
         fieldName={'telephone'}
+        fieldId={'telephone-id'}
         defaultCountry={'tw'}
         value={'0999 123 456'}
         utilsScript={'../example/assets/libphonenumber.js'}
@@ -44,6 +45,10 @@ describe('TelInput', () => {
 
   it('Set fieldName as "telephone"', () => {
     assert(inputComponent.props.fieldName === 'telephone');
+  });
+
+  it('Set fieldId as "telephone-id"', () => {
+    assert(inputComponent.props.fieldId === 'telephone-id');
   });
 
   it('onPhoneNumberChange without utilsScript', () => {


### PR DESCRIPTION
- Pass all props from `App.js` to `IntlTelInputApp.js` with the spread operator, easier and no need to keep updating it when. Let me know if that's ok, otherwise I can update the PR without this change