### PR TITLE
Define new callback `preprocessPlaceholder` optional prop

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -173,7 +173,7 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
               <tr>
                 <th scope="row">preprocessPlaceholder</th>
                 <td><code>null</code></td>
-                <td>Function callback that can preprocess the `autoPlaceholder` suggestion number. Takes a string (e.g., `(408) 123-1234`) and returns a new string (e.g., `(xxx) xxx-xxxx`).</td>
+                <td>Function callback that can preprocess the `autoPlaceholder` suggestion number. Takes two strings (e.g., placeholder text `(408) 123-1234`, and iso2 `us`) and returns a new string (e.g., `(xxx) xxx-xxxx`).</td>
               </tr>
               <tr>
                 <th scope="row">autoHideDialCode</th>

--- a/example/index.html
+++ b/example/index.html
@@ -171,6 +171,11 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Add or remove input placeholder with an example number for the selected country.</td>
               </tr>
               <tr>
+                <th scope="row">preprocessPlaceholder</th>
+                <td><code>null</code></td>
+                <td>Function callback that can preprocess the `autoPlaceholder` suggestion number. Takes a string (e.g., `(408) 123-1234`) and returns a new string (e.g., `(xxx) xxx-xxxx`).</td>
+              </tr>
+              <tr>
                 <th scope="row">autoHideDialCode</th>
                 <td><code>true</code></td>
                 <td>If there is just a dial code in the input: remove it on blur, and re-add it on focus.</td>

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -22,6 +22,7 @@ class IntlTelInput extends Component {
     allowExtensions: PropTypes.bool,
     autoFormat: PropTypes.bool,
     autoPlaceholder: PropTypes.bool,
+    preprocessPlaceholder: PropTypes.func,
     autoHideDialCode: PropTypes.bool,
     defaultCountry: PropTypes.string,
     geoIpLookup: PropTypes.func,
@@ -52,6 +53,7 @@ class IntlTelInput extends Component {
           allowExtensions={this.props.allowExtensions}
           autoFormat={this.props.autoFormat}
           autoPlaceholder={this.props.autoPlaceholder}
+          preprocessPlaceholder={this.props.preprocessPlaceholder}
           autoHideDialCode={this.props.autoHideDialCode}
           defaultCountry={this.props.defaultCountry}
           geoIpLookup={this.props.geoIpLookup}

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -24,6 +24,8 @@ class IntlTelInputApp extends Component {
     autoFormat: true,
     // add or remove input placeholder with an example number for the selected country
     autoPlaceholder: true,
+    // allow placeholder number suggestion to be processed before it is set in the field
+    preprocessPlaceholder: null,
     // if there is just a dial code in the input: remove it on blur, and re-add it on focus
     autoHideDialCode: true,
     // default country
@@ -53,6 +55,7 @@ class IntlTelInputApp extends Component {
     allowExtensions: PropTypes.bool,
     autoFormat: PropTypes.bool,
     autoPlaceholder: PropTypes.bool,
+    preprocessPlaceholder: PropTypes.func,
     autoHideDialCode: PropTypes.bool,
     defaultCountry: PropTypes.string,
     geoIpLookup: PropTypes.func,
@@ -753,8 +756,13 @@ class IntlTelInputApp extends Component {
       this.props.autoPlaceholder && this.selectedCountryData) {
       const iso2 = this.selectedCountryData.iso2;
       const numberType = window.intlTelInputUtils.numberType[this.props.numberType || 'FIXED_LINE'];
-      const placeholder = (iso2) ?
+      let placeholder = (iso2) ?
         window.intlTelInputUtils.getExampleNumber(iso2, this.props.nationalMode, numberType) : '';
+
+      if (typeof this.props.preprocessPlaceholder === 'function') {
+        placeholder = this.props.preprocessPlaceholder(placeholder);
+      }
+
       findDOMNode(this.refs.telInput).setAttribute('placeholder', placeholder);
     }
   }

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -760,7 +760,7 @@ class IntlTelInputApp extends Component {
         window.intlTelInputUtils.getExampleNumber(iso2, this.props.nationalMode, numberType) : '';
 
       if (typeof this.props.preprocessPlaceholder === 'function') {
-        placeholder = this.props.preprocessPlaceholder(placeholder);
+        placeholder = this.props.preprocessPlaceholder(placeholder, iso2);
       }
 
       findDOMNode(this.refs.telInput).setAttribute('placeholder', placeholder);

--- a/src/index.html
+++ b/src/index.html
@@ -173,7 +173,7 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
               <tr>
                 <th scope="row">preprocessPlaceholder</th>
                 <td><code>null</code></td>
-                <td>Function callback that can preprocess the `autoPlaceholder` suggestion number. Takes a string (e.g., `(408) 123-1234`) and returns a new string (e.g., `(xxx) xxx-xxxx`).</td>
+                <td>Function callback that can preprocess the `autoPlaceholder` suggestion number. Takes two strings (e.g., placeholder text `(408) 123-1234`, and iso2 `us`) and returns a new string (e.g., `(xxx) xxx-xxxx`).</td>
               </tr>
               <tr>
                 <th scope="row">autoHideDialCode</th>

--- a/src/index.html
+++ b/src/index.html
@@ -171,6 +171,11 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Add or remove input placeholder with an example number for the selected country.</td>
               </tr>
               <tr>
+                <th scope="row">preprocessPlaceholder</th>
+                <td><code>null</code></td>
+                <td>Function callback that can preprocess the `autoPlaceholder` suggestion number. Takes a string (e.g., `(408) 123-1234`) and returns a new string (e.g., `(xxx) xxx-xxxx`).</td>
+              </tr>
+              <tr>
                 <th scope="row">autoHideDialCode</th>
                 <td><code>true</code></td>
                 <td>If there is just a dial code in the input: remove it on blur, and re-add it on focus.</td>


### PR DESCRIPTION
- This callback allows users to preprocess the placeholders before setting them. So
it's possible to transform `(408) 123-1234` into `(xxx) xxx-xxxx` for example.