### PR TITLE
Add `preprocessValue` callback, just to allow users to change value a…

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -141,6 +141,11 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Value.</td>
               </tr>
               <tr>
+                <th scope="row">preprocessValue</th>
+                <td><code>null</code></td>
+                <td>Function callback that can preprocess the `value` while you type. Takes a string, and returns a new string.</td>
+              </tr>
+              <tr>
                 <th scope="row">fieldName</th>
                 <td><code>''</code></td>
                 <td>It's used as `input` field `name` attribute.</td>

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -13,6 +13,8 @@ export default class IntlTelInputApp extends Component {
     fieldName: '',
     fieldId: '',
     value: '',
+    // preprocess input value before setting state, any normalization can be done here
+    preprocessValue: null,
     // define the countries that'll be present in the dropdown
     // defaults to the data defined in `AllCountries`
     countriesData: null,
@@ -50,6 +52,7 @@ export default class IntlTelInputApp extends Component {
     fieldName: PropTypes.string,
     fieldId: PropTypes.string,
     value: PropTypes.string,
+    preprocessValue: PropTypes.func,
     countriesData: PropTypes.arrayOf(PropTypes.array),
     allowExtensions: PropTypes.bool,
     autoFormat: PropTypes.bool,
@@ -872,6 +875,10 @@ export default class IntlTelInputApp extends Component {
     } else {
       // no autoFormat, so just insert the original value
       formatted = val;
+    }
+
+    if (typeof this.props.preprocessValue === 'function') {
+      formatted = this.props.preprocessValue(formatted);
     }
 
     this.setState({

--- a/src/index.html
+++ b/src/index.html
@@ -141,6 +141,11 @@ ReactDOM.render(&lt;IntlTelInput onPhoneNumberChange={changeHandler}
                 <td>Value.</td>
               </tr>
               <tr>
+                <th scope="row">preprocessValue</th>
+                <td><code>null</code></td>
+                <td>Function callback that can preprocess the `value` while you type. Takes a string, and returns a new string.</td>
+              </tr>
+              <tr>
                 <th scope="row">fieldName</th>
                 <td><code>''</code></td>
                 <td>It's used as `input` field `name` attribute.</td>


### PR DESCRIPTION
…s they type
- This is useful to do normalizations, like transforming japanese numbers (e.g., １, ２, etc.) to the right alpha numbers (e.g., `1`, `2`, etc.).
- I wasn't able to change anything as the component seems to completely manage its own state and it doesn't take `defaultValue` property.. directly changing `value` makes the cursor jump like crazy.
- I tried adding a test for this, but `Simulate.change` and `Simulate.keyDown`
