### PR TITLE
implement state.value change in componentWillReceiveProps

### DIFF
--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -235,6 +235,14 @@ export default class IntlTelInputApp extends Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value !== nextProps.value) {
+      this.setState({
+        value: nextProps.value,
+      });
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
     this.unbindDocumentClick();

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-eval */
 import React from 'react';
-import { findDOMNode } from 'react-dom';
+import { findDOMNode, render } from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';
 import IntlTelInput from '../src/containers/IntlTelInputApp';
 import TelInput from '../src/components/TelInput';
@@ -381,5 +381,27 @@ describe('TelInput', () => {
 
     ReactTestUtils.Simulate.change(findDOMNode(input), { target: { value: '910123456' } });
     assert(parent.getFullNumber() === '+886910123456');
+  });
+
+  it('should change input value on value prop change', () => {
+    const node = document.createElement('div');
+    const component = render(
+      <IntlTelInput css={['intl-tel-input', 'form-control phoneNumber']}
+        value={'0999 123 456'}
+      />
+    , node);
+
+    render(
+      <IntlTelInput css={['intl-tel-input', 'form-control phoneNumber']}
+        value={'foo bar'}
+      />
+    , node);
+
+    inputComponent = ReactTestUtils.findRenderedComponentWithType(
+      component,
+      TelInput
+    );
+
+    assert.equal(inputComponent.props.value, 'foo bar');
   });
 });


### PR DESCRIPTION
Fixes #126. It updates inner input value on components value change. Useful when you want to do some validation on `onPhoneNumberChange` or `onSelectFlag`