### PR TITLE
Add the ability to replace the input element with something custom

### DIFF
--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -13,23 +13,24 @@ class TelInput extends Component {
     handleKeyPress: PropTypes.func,
     handleOnBlur: PropTypes.func,
     autoFocus: PropTypes.bool,
+    renderer: PropTypes.func,
   };
 
   render() {
-    return (
-      <input type="tel" autoComplete="off"
-        className={this.props.className}
-        disabled={this.props.disabled ? 'disabled' : false}
-        readOnly={this.props.readonly ? 'readonly' : false}
-        name={this.props.fieldName}
-        id={this.props.fieldId}
-        value={this.props.value}
-        placeholder={this.props.placeholder}
-        onChange={this.props.handleInputChange}
-        onBlur={this.props.handleOnBlur}
-        autoFocus={this.props.autoFocus}
-      />
-    );
+    return this.props.renderer({
+      type: 'tel',
+      autoComplete: 'off',
+      className: this.props.className,
+      disabled: this.props.disabled ? 'disabled' : false,
+      readOnly: this.props.readonly ? 'readonly' : false,
+      name: this.props.fieldName,
+      id: this.props.fieldId,
+      value: this.props.value,
+      placeholder: this.props.placeholder,
+      onChange: this.props.handleInputChange,
+      onBlur: this.props.handleOnBlur,
+      autoFocus: this.props.autoFocus,
+    });
   }
 }
 

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -81,6 +81,7 @@ export default class IntlTelInputApp extends Component {
     disabled: PropTypes.bool,
     placeholder: PropTypes.string,
     autoFocus: PropTypes.bool,
+    inputRenderer: PropTypes.func,
   };
 
   constructor(props) {
@@ -1070,9 +1071,14 @@ export default class IntlTelInputApp extends Component {
     });
   }
 
+  defaultInputRenderer(props) {
+    return React.createElement('input', props);
+  }
+
   render() {
     this.wrapperClass[this.props.css[0]] = true;
     const inputClass = this.props.css[1];
+    const inputRenderer = this.props.inputRenderer || this.defaultInputRenderer;
 
     if (this.state.showDropdown) {
       this.wrapperClass.expanded = true;
@@ -1115,6 +1121,7 @@ export default class IntlTelInputApp extends Component {
           value={this.state.value}
           placeholder={this.state.placeholder}
           autoFocus={this.props.autoFocus}
+          renderer={inputRenderer}
         />
       </div>
     );

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -492,4 +492,24 @@ describe('TelInput', () => {
 
     assert.notEqual(document.activeElement, inputDOMNode);
   });
+
+  it('defaults to a plain input if a renderer is not specified', () => {
+    assert.equal(inputComponent._reactInternalInstance._renderedComponent._tag, 'input');
+  });
+
+  it('allows the user to pass in an alternate renderer', () => {
+    const renderedComponent = ReactTestUtils.renderIntoDocument(
+      <IntlTelInput css={['intl-tel-input', 'form-control phoneNumber']}
+        inputRenderer={( props ) => React.createElement('textarea', props)}
+      />
+    );
+
+    const inputComponent = ReactTestUtils.findRenderedComponentWithType(
+      renderedComponent,
+      TelInput
+    );
+
+    assert.equal(inputComponent._reactInternalInstance._renderedComponent._tag, 'textarea');
+  });
+
 });


### PR DESCRIPTION
This will be a step in the right direction for solving #134.

This change will allow you to pass a prop to `<IntlTelInput/>` that creates the `<input>` (or whatever you want) for inputting the phone number.

For example, if for some insane reason you wanted to use a textarea, it would be as simple as:

``` js
<IntlTelInput
    css={[ 'intl-tel-input', 'form-control' ]}
    inputRenderer={ props => <textarea {...props} /> }
/>
```

... or if you prefer:

``` js
<IntlTelInput
    css={[ 'intl-tel-input', 'form-control' ]}
    inputRenderer={ ( props ) => { return React.createElement( 'textarea', props ); } }
/>
```

For a better example, you might want to use an input masking plugin, but they're all implemented as wrappers for `<input>`. Now you can set your telephone input renderer as a masked input.
### Tests

This is the first time I've done any react component testing. I'm not sure if I broke any rules with the properties that I referenced, or if there's a better way to assert what I'm asserting.  But the tests pass so 🎉 !
### Docs

Once you're happy with this PR and give me the 👍 I'll add the necessary docs to the readme to explain this change. (So don't merge this PR until the docs have been added)
