### PR TITLE
Add prop to turn off mobile fullscreen

### DIFF
--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -18,6 +18,7 @@ class CountryList extends Component {
     highlightedCountry: PropTypes.number,
     changeHighlightCountry: PropTypes.func,
     showDropdown: PropTypes.bool,
+    isMobile: PropTypes.bool,
   };
 
   constructor() {
@@ -84,7 +85,7 @@ class CountryList extends Component {
           className={countryClass}
           data-dial-code={country.dialCode}
           data-country-code={country.iso2}
-          onMouseOver={this.handleMouseOver}
+          onMouseOver={this.props.isMobile ? undefined : this.handleMouseOver}
           onClick={partial(this.setFlag, country.iso2)}
         >
           <div ref="selectedFlag" className="flag-box">

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -8,6 +8,9 @@ import utils from '../components/utils';
 import _ from 'underscore.deferred';
 import '../styles/intlTelInput.scss';
 
+const mobileUserAgentRegexp =
+  /Android.+Mobile|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
 export default class IntlTelInputApp extends Component {
   static defaultProps = {
     css: ['intl-tel-input', ''],
@@ -98,8 +101,7 @@ export default class IntlTelInputApp extends Component {
     this.utilsScriptDeferred = new _.Deferred();
 
     this.isOpening = false;
-    this.isMobile = /Android.+Mobile|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      navigator.userAgent);
+    this.isMobile = mobileUserAgentRegexp.test(navigator.userAgent);
     this.preferredCountries = [];
     this.countries = [];
     this.countryCodes = {};

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -55,6 +55,8 @@ export default class IntlTelInputApp extends Component {
     onSelectFlag: null,
     disabled: false,
     autoFocus: false,
+    // whether to use fullscreen flag dropdown for mobile useragents
+    useMobileFullscreenDropdown: true,
   };
 
   static propTypes = {
@@ -85,6 +87,7 @@ export default class IntlTelInputApp extends Component {
     placeholder: PropTypes.string,
     autoFocus: PropTypes.bool,
     style: PropTypes.object,
+    useMobileFullscreenDropdown: PropTypes.bool,
   };
 
   constructor(props) {
@@ -305,7 +308,7 @@ export default class IntlTelInputApp extends Component {
     this.wrapperClass['allow-dropdown'] = this.allowDropdown;
     this.wrapperClass['separate-dial-code'] = this.props.separateDialCode;
 
-    if (this.isMobile) {
+    if (this.isMobile && this.props.useMobileFullscreenDropdown) {
       utils.addClass(document.querySelector('body'), 'iti-mobile');
       // on mobile, we want a full screen dropdown, so we must append it to the body
       this.dropdownContainer = 'body';

--- a/src/index.html
+++ b/src/index.html
@@ -271,6 +271,11 @@ ReactDOM.render(&lt;IntlTelInput style={{ width: '100%', backgroundColor: 'red' 
                 <td><code>null</code></td>
                 <td>Optional validation callback function. It returns validation status, input box value and selected country data.</td>
               </tr>
+              <tr>
+                <th scope="row">useMobileFullscreenDropdown</th>
+                <td><code>true</code></td>
+                <td>Render fullscreen flag dropdown when mobile useragent is detected. The dropdown element is rendered as a direct child of <code>document.body</code></td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/src/styles/intlTelInput.scss
+++ b/src/styles/intlTelInput.scss
@@ -161,6 +161,7 @@ $mobilePopupMargin: 30px;
 
     max-height: 200px;
     overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
 
     // the divider below the preferred countries
     .divider {
@@ -279,6 +280,7 @@ $mobilePopupMargin: 30px;
   .country-list {
     max-height: 100%;
     width: 100%;
+    -webkit-overflow-scrolling: touch;
     .country {
       padding: 10px 10px;
       // increase line height because dropdown copy is v likely to overflow on mobile and when it does it needs to be well spaced

--- a/src/styles/intlTelInput.scss
+++ b/src/styles/intlTelInput.scss
@@ -200,6 +200,7 @@ $mobilePopupMargin: 30px;
     .flag-container {
       right: auto;
       left: 0;
+      width: 100%;
     }
     .selected-flag {
       width: $selectedFlagArrowWidth;

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -4,6 +4,7 @@ import { findDOMNode, render } from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';
 import IntlTelInput from '../src/containers/IntlTelInputApp';
 import TelInput from '../src/components/TelInput';
+import FlagDropDown from '../src/components/FlagDropDown';
 import sinon from 'sinon';
 import fs from 'fs';
 import { assert } from 'chai';
@@ -494,5 +495,36 @@ describe('TelInput', () => {
     const inputDOMNode = findDOMNode(input);
 
     assert.notEqual(document.activeElement, inputDOMNode);
+  });
+
+  context('when mobile useragent', () => {
+    let defaultUserAgent;
+    const findFlagDropdown = (parentComponent) => ReactTestUtils.findRenderedComponentWithType(
+      parentComponent,
+      FlagDropDown
+    );
+
+    before('set useragent to mobile', () => {
+      defaultUserAgent = navigator.userAgent;
+      navigator.__defineGetter__('userAgent', () => 'iPhone');
+    });
+
+    after('restore previous useragent', () => {
+      navigator.__defineGetter__('userAgent', () => defaultUserAgent);
+    });
+
+    it('sets FlagDropDown "dropdowncontainer" prop to "body"', () => {
+      const flagDropdown = findFlagDropdown(renderedComponent);
+      assert.equal(flagDropdown.props.dropdownContainer, 'body');
+    });
+
+    it('sets FlagDropDown "isMobile" prop to true', () => {
+      const flagDropdown = findFlagDropdown(renderedComponent);
+      assert.equal(flagDropdown.props.isMobile, true);
+    });
+
+    it('sets "iti-mobile" class to "body"', () => {
+      assert.include(document.body.className, 'iti-mobile');
+    });
   });
 });

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -16,8 +16,11 @@ describe('TelInput', () => {
   let requests;
   let getScript;
 
-  beforeEach('Render element', () => {
+  before('Read utils file', () => {
     libphonenumberUtils = fs.readFileSync('./example/assets/libphonenumber.js', 'utf8');
+  });
+
+  beforeEach('Render element', () => {
     xhr = sinon.useFakeXMLHttpRequest();
     window.intlTelInputUtils = undefined;
     requests = [];

--- a/tests/TelInput-test.js
+++ b/tests/TelInput-test.js
@@ -526,5 +526,17 @@ describe('TelInput', () => {
     it('sets "iti-mobile" class to "body"', () => {
       assert.include(document.body.className, 'iti-mobile');
     });
+
+    it(`does not set FlagDropDown "dropdowncontainer" to "body"
+       when "useMobileFullscreenDropdown" set to false`, () => {
+      renderedComponent = ReactTestUtils.renderIntoDocument(
+        <IntlTelInput css={['intl-tel-input', 'form-control phoneNumber']}
+          utilsScript={'../example/assets/libphonenumber.js'}
+          useMobileFullscreenDropdown={false}
+        />
+      );
+      const flagDropdown = findFlagDropdown(renderedComponent);
+      assert.equal(flagDropdown.props.dropdownContainer, '');
+    });
   });
 });


### PR DESCRIPTION
When mobile useragent is detected, the flag dropdown is rendered as a
direct child of `document.body`. This might be undesirable for
use-cases when the telephone input must be strictly contained in a
certain DOM element.

Add `useMobileFullScreen` prop to `IntlTelInputApp` which specifies
whether to use the _fullscreen_ rendering for mobile useragents.
`useMobileFullScreen` defaults to `true` and is thus backwards
compatible.