### PR TITLE
make autocomplete prop configurable

### DIFF
--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -13,11 +13,12 @@ class TelInput extends Component {
     handleKeyPress: PropTypes.func,
     handleOnBlur: PropTypes.func,
     autoFocus: PropTypes.bool,
+    autoComplete: PropTypes.string,
   };
 
   render() {
     return (
-      <input type="tel" autoComplete="off"
+      <input type="tel" autoComplete={this.props.autoComplete}
         className={this.props.className}
         disabled={this.props.disabled ? 'disabled' : false}
         readOnly={this.props.readonly ? 'readonly' : false}
@@ -32,5 +33,6 @@ class TelInput extends Component {
     );
   }
 }
+
 
 export default TelInput;

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -52,6 +52,7 @@ export default class IntlTelInputApp extends Component {
     onSelectFlag: null,
     disabled: false,
     autoFocus: false,
+    autoComplete: 'off',
   };
 
   static propTypes = {
@@ -81,6 +82,7 @@ export default class IntlTelInputApp extends Component {
     disabled: PropTypes.bool,
     placeholder: PropTypes.string,
     autoFocus: PropTypes.bool,
+    autoComplete: PropTypes.string,
     style: PropTypes.object,
   };
 
@@ -1118,6 +1120,7 @@ export default class IntlTelInputApp extends Component {
           value={this.state.value}
           placeholder={this.state.placeholder}
           autoFocus={this.props.autoFocus}
+          autoComplete={this.props.autoComplete}
         />
       </div>
     );

--- a/src/index.html
+++ b/src/index.html
@@ -182,6 +182,11 @@ ReactDOM.render(&lt;IntlTelInput style={{ width: '100%', backgroundColor: 'red' 
                 <td>Whether or not to allow the dropdown. If disabled, there is no dropdown arrow, and the selected flag is not clickable. Also we display the selected flag on the right instead because it is just a marker of state.</td>
               </tr>
               <tr>
+                <th scope="row">autoComplete</th>
+                <td><code>off</code></td>
+                <td>Set the value of the <code>autoComplete</code> attribute on the input. For example, set it to <code>phone</code> to tell the browser where to autocompllete phone numbers.</td>
+              </tr>
+              <tr>
                 <th scope="row">autoPlaceholder</th>
                 <td><code>true</code></td>
                 <td>Add or remove input placeholder with an example number for the selected country.</td>


### PR DESCRIPTION
I have a form containing a phone input and this is the only field that's not being autofilled. It would be nice if we could configure it to allow autocompletion with, e.g.

    <IntlTelInput autoComplete={'tel'} />

The default values are setup to be backwards compatible.