### PR TITLE
Pass arbitrary props to the tel input element

### DIFF
--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -14,11 +14,15 @@ class TelInput extends Component {
     handleOnBlur: PropTypes.func,
     autoFocus: PropTypes.bool,
     autoComplete: PropTypes.string,
+    inputProps: PropTypes.object,
   };
 
   render() {
     return (
-      <input type="tel" autoComplete={this.props.autoComplete}
+      <input
+        {...this.props.inputProps}
+        type="tel"
+        autoComplete={this.props.autoComplete}
         className={this.props.className}
         disabled={this.props.disabled ? 'disabled' : false}
         readOnly={this.props.readonly ? 'readonly' : false}

--- a/src/containers/IntlTelInputApp.js
+++ b/src/containers/IntlTelInputApp.js
@@ -58,6 +58,8 @@ export default class IntlTelInputApp extends Component {
     // whether to use fullscreen flag dropdown for mobile useragents
     useMobileFullscreenDropdown: true,
     autoComplete: 'off',
+    // pass through arbitrary props to the tel input element
+    telInputProps: {},
   };
 
   static propTypes = {
@@ -90,6 +92,7 @@ export default class IntlTelInputApp extends Component {
     autoComplete: PropTypes.string,
     style: PropTypes.object,
     useMobileFullscreenDropdown: PropTypes.bool,
+    telInputProps: PropTypes.object,
   };
 
   constructor(props) {
@@ -1126,6 +1129,7 @@ export default class IntlTelInputApp extends Component {
           placeholder={this.state.placeholder}
           autoFocus={this.props.autoFocus}
           autoComplete={this.props.autoComplete}
+          inputProps={this.props.telInputProps}
         />
       </div>
     );

--- a/src/index.html
+++ b/src/index.html
@@ -281,6 +281,11 @@ ReactDOM.render(&lt;IntlTelInput style={{ width: '100%', backgroundColor: 'red' 
                 <td><code>true</code></td>
                 <td>Render fullscreen flag dropdown when mobile useragent is detected. The dropdown element is rendered as a direct child of <code>document.body</code></td>
               </tr>
+              <tr>
+                <th scope="row">telInputProps</th>
+                <td><code>{}</code></td>
+                <td>Pass through arbitrary props to the tel input element.</td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
HTML input element supports few attributes more than it is possible to configure via the IntlTelInputApp props. Since adding all of them seems to be a little bit of an overhead, new telInputProps should provide usage flexibility (e.g. maxLenght, required, etc.).