### PR TITLE
Blank Flag HotFix

### DIFF
--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -719,7 +719,7 @@ class IntlTelInputApp extends Component {
       // invalid dial code, so empty
       // Note: use getNumeric here because the number has not been
       // formatted yet, so could contain bad chars
-      countryCode = '';
+      countryCode = null;
     } else if (!number || number === '+') {
       // empty, or just a plus, so default
       countryCode = this.defaultCountry;


### PR DESCRIPTION
When typing a number and specifying a country code, the flag icon turns blank. This is more noticeable when using onlyCounties since a country may not be in the list. eg => +44 when the UK is not in the list results in a blank flag.

This also occurs when you are in mid type of providing a country code. +4 does not exist. +44 does. So while +4 is showing, a blank flag will be displayed.