### PR TITLE
Allow country code to be deleted

### DIFF
--- a/__tests__/TelInput.test.js
+++ b/__tests__/TelInput.test.js
@@ -446,6 +446,16 @@ describe('TelInput', function () { // eslint-disable-line func-names
       subject.setProps({ value: 'foo bar' });
       expect(inputComponent.props().value).toBe('foo bar');
     });
+
+    it('should be able to delete country code after input field has been populated with number', () => {
+      const subject = this.makeSubject();
+
+      subject.setProps({ value: '+447598455159' });
+
+      subject.setProps({ value: '+' });
+
+      expect(subject.state().value).toBe('+');
+    });
   });
 
   describe('uncontrolled', () => {

--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -726,9 +726,6 @@ class IntlTelInputApp extends Component {
       // Note: use getNumeric here because the number has not been
       // formatted yet, so could contain bad chars
       countryCode = null;
-    } else if (!number || number === '+') {
-      // empty, or just a plus, so default
-      countryCode = this.defaultCountry;
     }
 
     if (countryCode !== null) {


### PR DESCRIPTION
Currently country code in the input field can't be deleted on a controlled or uncontrolled component
https://github.com/patw0929/react-intl-tel-input/issues/197

If the user deletes the numbers of the country code and only has "+" in value. updateFlagFromNumber will populate the flag to the default country which in turn will populate the input field with the default code. 

I've removed the setting a default country code because the default country is always the currently selected flag and seems to be redundant (Let me know if i'm wrong ).

Here is where default country is set: https://github.com/MatthewAnstey/react-intl-tel-input/blob/c731a6b913b5d8852d886c4b0e35ae7cbc7c37b7/src/components/IntlTelInputApp.js#L241 on every flag change, making it redundant. I think its redundant because its the same as the currently selected flag.

Although this fixes the bug. I think we should decide what default country was suppose to do (apart from obviously setting the default country). I'm guessing it was meant to update the flag to default flag when just '+' was typed? If this is case I think we should remove  https://github.com/MatthewAnstey/react-intl-tel-input/blob/c731a6b913b5d8852d886c4b0e35ae7cbc7c37b7/src/components/IntlTelInputApp.js#L241 and look at a different fix for this.