### PR TITLE
Move Prop-types out of peer dependency. remove proptypes in dist.

### DIFF
--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -28,6 +28,8 @@ module.exports = {
       // You can safely remove this after ejecting:
       moduleName: path.dirname(require.resolve('babel-runtime/package'))
     }],
+    // Get rid of proptypes in dist.
+    require.resolve('babel-plugin-transform-react-remove-prop-types'),
     // Optimization: hoist JSX that never changes out of render()
     // Disabled because of issues:
     // * https://github.com/facebookincubator/create-react-app/issues/525

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "main": "dist/main.js",
   "peerDependencies": {
-    "prop-types": "~15.5.8",
     "react": ">15.4.2 <17.0.0",
     "react-dom": ">15.4.2 <17.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.6.1",
     "react-style-proptype": "^3.0.0",
     "underscore.deferred": "^0.4.0"
   },
@@ -38,6 +38,7 @@
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-plugin-transform-react-constant-elements": "^6.9.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-plugin-transform-regenerator": "^6.21.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-latest": "^6.16.0",
@@ -77,7 +78,6 @@
     "lint-staged": "^3.2.6",
     "node-sass": "^4.2.0",
     "pre-commit": "^1.2.2",
-    "prop-types": "^15.6.1",
     "raf": "^3.4.0",
     "react": "^16.2.0",
     "react-dev-utils": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,6 +780,10 @@ babel-plugin-transform-react-jsx@^6.22.0, babel-plugin-transform-react-jsx@^6.23
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz#331cfc05099a808238311d78319c27460d481189"
+
 babel-plugin-transform-regenerator@6.22.0, babel-plugin-transform-regenerator@^6.21.0, babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.6.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz#65740593a319c44522157538d690b84094617ea6"


### PR DESCRIPTION
Remove proptypes from peer dependency (was throwing warning which brought me here 😄 ). As per: https://github.com/facebook/prop-types/issues/44#issuecomment-299238787

Moved proptypes to dependencies (similar to the style-proptype lib).

Added babel plugin to remove proptypes from dist, as they aren't executed.

main.js 76kb -> 74kb.