### PR TITLE
Add findIndex implementation for IE 11

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -156,4 +156,21 @@ describe('utils', () => {
 
     expect(element.classList.contains('abc')).toBeFalsy();
   });
+
+  it('findIndex', () => {
+    let array = [];
+    let predicate = () => true;
+
+    expect(utils.findIndex(array, predicate)).toEqual(-1);
+
+    array = [1, 2, 3];
+    predicate = (item) => item === 2;
+
+    expect(utils.findIndex(array, predicate)).toEqual(1);
+
+    array = [1, 2, 3];
+    predicate = (item) => item === 4;
+
+    expect(utils.findIndex(array, predicate)).toEqual(-1);
+  });
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -61,6 +61,7 @@ describe('utils', () => {
     expect(utils.trim(undefined)).toBe('');
 
     const str = ' Hello World   ';
+
     expect(utils.trim(str)).toBe('Hello World');
   });
 
@@ -83,6 +84,7 @@ describe('utils', () => {
     expect(utils.retrieveLiIndex(bListItem)).toBe(1);
 
     const otherListItem = doc.querySelector('.z');
+
     expect(utils.retrieveLiIndex(otherListItem)).toBe(-1);
   });
 

--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -268,10 +268,10 @@ class IntlTelInputApp extends Component {
     let selectedIndex = 0;
 
     if (countryCode && countryCode !== 'auto') {
-      selectedIndex = this.preferredCountries.findIndex((country) => country.iso2 === countryCode);
+      selectedIndex = utils.findIndex(this.preferredCountries, (country) => country.iso2 === countryCode);
 
       if (selectedIndex === -1) {
-        selectedIndex = this.countries.findIndex((country) => country.iso2 === countryCode);
+        selectedIndex = utils.findIndex(this.countries, (country) => country.iso2 === countryCode);
         if (selectedIndex === -1) selectedIndex = 0;
         selectedIndex += this.preferredCountries.length;
       }

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -182,4 +182,14 @@ export default {
       el.className = el.className.replace(reg, ' ');
     }
   },
+  findIndex(items, predicate) {
+    var index = -1;
+    items.some((item, i) => {
+        if (predicate(item)) {
+          index = i;
+          return true;
+        }
+    });
+    return index;
+  },
 };


### PR DESCRIPTION
`findIndex` is not available in IE 11.

There is `core-js` polyfill available [1], however would like to avoid
using it as our app runs on top of other sites as a widget and we do not
want to define any kinds of globally available functions.

Instead use `some` which is implemented in IE 11.

[1]: https://github.com/zloirock/core-js/tree/v2#ecmascript-6-array