### PR TITLE
[#218] Fix expanded class not being removed from wrapper

### DIFF
--- a/__tests__/TelInput.test.js
+++ b/__tests__/TelInput.test.js
@@ -497,6 +497,19 @@ describe('TelInput', function () { // eslint-disable-line func-names
 
       expect(subject.find(TelInput).props().placeholder).toBe('Your phone');
     });
+
+    it('should set "expanded" class to wrapper only when flags are open', () => {
+      const subject = this.makeSubject();
+      const flagComponent = subject.find(FlagDropDown).find('.selected-flag');
+
+      flagComponent.simulate('click');
+      expect(subject.instance().wrapperClass.expanded).toBe(true);
+
+      const taiwanOption = subject.find(FlagDropDown).find('[data-country-code="tw"]');
+
+      taiwanOption.simulate('click');
+      expect(subject.instance().wrapperClass.expanded).toBe(false);
+    });
   });
 
   describe('uncontrolled', () => {

--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -1121,9 +1121,7 @@ class IntlTelInputApp extends Component {
     const inputClass = this.props.css[1];
     const wrapperStyle = Object.assign({}, this.props.style || {});
 
-    if (this.state.showDropdown) {
-      this.wrapperClass.expanded = true;
-    }
+    this.wrapperClass.expanded = this.state.showDropdown;
 
     const wrapperClass = classNames(this.wrapperClass);
 


### PR DESCRIPTION
As we are attaching global "expanded" class to the wrapper
when countries are open, this class is not being removed once
country is selected and dropdown closed.

Fixes #218