### PR TITLE
Removed second argument of parseFloat

### DIFF
--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -829,7 +829,7 @@ class IntlTelInputApp extends Component {
     try {
       const container = this.flagDropDown.querySelector('.country-list');
       const containerHeight = parseFloat(
-        window.getComputedStyle(container).getPropertyValue('height'), 10);
+        window.getComputedStyle(container).getPropertyValue('height'));
       const containerTop = utils.offset(container).top;
       const containerBottom = containerTop + containerHeight;
       const elementHeight = utils.getOuterHeight(element);


### PR DESCRIPTION
Syntax issue:
`parseFloat` shouldn't has the second argument.
ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat

Should removed it.