### PR TITLE
Hide country list when click on flag button

### DIFF
--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -808,6 +808,9 @@ class IntlTelInputApp extends Component {
           this.scrollTo(highlightItem, true);
         }
       });
+    } else if (this.state.showDropdown) {
+      // need to hide dropdown when click on opened flag button
+      this.toggleDropdown(false);
     }
   }
 
@@ -1059,9 +1062,15 @@ class IntlTelInputApp extends Component {
 
   handleDocumentClick(e) {
     // Click at the outside of country list
-    if (e.target.getAttribute('class') === null ||
-      (e.target.getAttribute('class') &&
-       e.target.getAttribute('class').indexOf('country') === -1)) {
+    // and outside of flag button
+    const targetClass = e.target.getAttribute('class');
+
+    if (targetClass === null ||
+      (targetClass &&
+      targetClass.indexOf('country') === -1 &&
+      targetClass.indexOf('selected-flag') === -1 &&
+      targetClass.indexOf('iti-flag') === -1 &&
+      targetClass.indexOf('iti-arrow') === -1)) {
       this.isOpening = false;
     }
 


### PR DESCRIPTION
Hi guys, 
i use your component and noticed that in difference from origin widget it not close country list when click on the same flag button. This creates inconvenience in UX when switch from jQuery to React because many users wait same behavior.

I didn't dive deep into logic and find few places where it can be fixed. 
It will be great either you make own fixes or use my and this bug will be fixed 👌

Thanks