### PR TITLE
Fixes #235: Show countrylist when allowDropdown flag is set to true

### DIFF
--- a/src/components/FlagDropDown.js
+++ b/src/components/FlagDropDown.js
@@ -66,7 +66,7 @@ export default class FlagDropDown extends Component {
               }}
               dropdownContainer={this.props.dropdownContainer}
               isMobile={this.props.isMobile}
-              showDropdown={this.props.showDropdown}
+              showDropdown={this.props.allowDropdown && this.props.showDropdown}
               setFlag={this.props.setFlag}
               countries={this.props.countries}
               inputTop={this.props.inputTop}
@@ -86,7 +86,7 @@ export default class FlagDropDown extends Component {
           }}
           dropdownContainer={this.props.dropdownContainer}
           isMobile={this.props.isMobile}
-          showDropdown={this.props.showDropdown}
+          showDropdown={this.props.allowDropdown && this.props.showDropdown}
           setFlag={this.props.setFlag}
           countries={this.props.countries}
           inputTop={this.props.inputTop}


### PR DESCRIPTION
Right now when `allowDropdown` is set to false, user can still click on the flag and list of countries is shown. This change makes sure `allowDropdown` is set to `true` before showing list of countries.