### PR TITLE
Fixed not update value issue when value is empty string

### DIFF
--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -15,7 +15,7 @@ class IntlTelInputApp extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     let newState = null;
 
-    if (nextProps.value && prevState.value !== nextProps.value) {
+    if (typeof nextProps.value !== 'undefined' && prevState.value !== nextProps.value) {
       newState = {
         value: nextProps.value,
       };

--- a/src/example.js
+++ b/src/example.js
@@ -40,14 +40,11 @@ class DemoComponent extends Component {
     this.selectFlagHandler2 = this.selectFlagHandler.bind(this, 'phone2');
   }
 
-  changeHandler(name, isValid, value, countryData, number, ext) {
-    log(isValid, value, countryData, number, ext);
-    this.setState({
-      [name]: value,
-    });
-  }
+  blurHandler = (name, isValid, value, countryData, number, ext, event) => {
+    log(isValid, value, countryData, number, ext, event.type);
+  };
 
-  blurHandler(name, isValid, value, countryData, number, ext) {
+  changeHandler(name, isValid, value, countryData, number, ext) {
     log(isValid, value, countryData, number, ext);
     this.setState({
       [name]: value,


### PR DESCRIPTION
Fixed the issue of not updating value when value is empty string.

1. We should let empty value also can be updated in `getDerivedStateFromProps`.
2. No need to `setState` in `blurHandler` event in example.

# Before

<img src="http://g.recordit.co/X7yNux60n9.gif" />

---

# After

<img src="http://g.recordit.co/wKulbRfGn7.gif" />