### PR TITLE
update cursor position after focused

### DIFF
--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -21,7 +21,7 @@ export default class TelInput extends Component {
 
   state = {
     hasFocus: false,
-  }
+  };
 
   componentDidUpdate() {
     if (this.state.hasFocus) {
@@ -37,17 +37,17 @@ export default class TelInput extends Component {
     this.props.refCallback(element);
   };
 
-  inputOnBlur = () => {
+  inputOnBlur = event => {
     this.setState({ hasFocus: false });
 
     if (this.props.handleOnBlur) {
-      this.props.handleOnBlur();
+      this.props.handleOnBlur(event);
     }
-  }
+  };
 
   inputOnFocus = () => {
     this.setState({ hasFocus: true });
-  }
+  };
 
   render() {
     return (

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -19,17 +19,35 @@ export default class TelInput extends Component {
     cursorPosition: PropTypes.number,
   };
 
+  state = {
+    hasFocus: false,
+  }
+
   componentDidUpdate() {
-    this.tel.setSelectionRange(
-      this.props.cursorPosition,
-      this.props.cursorPosition
-    );
+    if (this.state.hasFocus) {
+      this.tel.setSelectionRange(
+        this.props.cursorPosition,
+        this.props.cursorPosition
+      );
+    }
   }
 
   refHandler = element => {
     this.tel = element;
     this.props.refCallback(element);
   };
+
+  inputOnBlur = () => {
+    this.setState({ hasFocus: false });
+
+    if (this.props.handleOnBlur) {
+      this.props.handleOnBlur();
+    }
+  }
+
+  inputOnFocus = () => {
+    this.setState({ hasFocus: true });
+  }
 
   render() {
     return (
@@ -46,7 +64,8 @@ export default class TelInput extends Component {
         value={this.props.value}
         placeholder={this.props.placeholder}
         onChange={this.props.handleInputChange}
-        onBlur={this.props.handleOnBlur}
+        onBlur={this.inputOnBlur}
+        onFocus={this.inputOnFocus}
         autoFocus={this.props.autoFocus}
       />
     );


### PR DESCRIPTION
This commit fixed an issue like this. There are two Inputs in a form on my login page. The phone number input will get focus after entering every one character in password input.  Because the form managed the inputs together.