### PR TITLE
Fixed the issue of pasting number to text input cannot update flag in international mode

### DIFF
--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -806,7 +806,7 @@ class IntlTelInputApp extends Component {
     this.processPreferredCountries.call(this);
   };
 
-  handleOnBlur = (event) => {
+  handleOnBlur = e => {
     this.removeEmptyDialCode();
     if (typeof this.props.onPhoneNumberBlur === 'function') {
       const value = this.state.value;
@@ -819,7 +819,7 @@ class IntlTelInputApp extends Component {
         this.selectedCountryData,
         fullNumber,
         this.getExtension(value),
-        event
+        e
       );
     }
   };

--- a/src/components/IntlTelInputApp.js
+++ b/src/components/IntlTelInputApp.js
@@ -1217,6 +1217,12 @@ class IntlTelInputApp extends Component {
     }
   };
 
+  handlePaste = e => {
+    if (e.clipboardData) {
+      this.updateFlagFromNumber(e.clipboardData.getData('Text'), false);
+    }
+  };
+
   changeHighlightCountry = (showDropdown, selectedIndex) => {
     this.setState({
       showDropdown,
@@ -1282,6 +1288,7 @@ class IntlTelInputApp extends Component {
           refCallback={this.setTelRef}
           handleInputChange={this.handleInputChange}
           handleOnBlur={this.handleOnBlur}
+          handlePaste={this.handlePaste}
           className={inputClass}
           disabled={this.state.disabled}
           readonly={this.state.readonly}

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -11,6 +11,7 @@ export default class TelInput extends Component {
     value: PropTypes.string,
     placeholder: PropTypes.string,
     handleInputChange: PropTypes.func,
+    handlePaste: PropTypes.func,
     handleOnBlur: PropTypes.func,
     autoFocus: PropTypes.bool,
     autoComplete: PropTypes.string,
@@ -49,6 +50,12 @@ export default class TelInput extends Component {
     this.setState({ hasFocus: true });
   };
 
+  handlePaste = event => {
+    if (typeof this.props.handlePaste === 'function') {
+      this.props.handlePaste(event);
+    }
+  };
+
   render() {
     return (
       <input
@@ -64,6 +71,7 @@ export default class TelInput extends Component {
         value={this.props.value}
         placeholder={this.props.placeholder}
         onChange={this.props.handleInputChange}
+        onPaste={this.handlePaste}
         onBlur={this.inputOnBlur}
         onFocus={this.inputOnFocus}
         autoFocus={this.props.autoFocus}

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -38,21 +38,21 @@ export default class TelInput extends Component {
     this.props.refCallback(element);
   };
 
-  inputOnBlur = event => {
+  handleBlur = e => {
     this.setState({ hasFocus: false });
 
-    if (this.props.handleOnBlur) {
-      this.props.handleOnBlur(event);
+    if (typeof this.props.handleOnBlur === 'function') {
+      this.props.handleOnBlur(e);
     }
   };
 
-  inputOnFocus = () => {
+  handleFocus = () => {
     this.setState({ hasFocus: true });
   };
 
-  handlePaste = event => {
+  handlePaste = e => {
     if (typeof this.props.handlePaste === 'function') {
-      this.props.handlePaste(event);
+      this.props.handlePaste(e);
     }
   };
 
@@ -72,8 +72,8 @@ export default class TelInput extends Component {
         placeholder={this.props.placeholder}
         onChange={this.props.handleInputChange}
         onPaste={this.handlePaste}
-        onBlur={this.inputOnBlur}
-        onFocus={this.inputOnFocus}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
         autoFocus={this.props.autoFocus}
       />
     );


### PR DESCRIPTION
## Description

As #252 said, when pasting a full number in international mode, the flag won't update.
But it works great when typing from the beginning.

In #252, @Samb102 provided their [workaround](https://github.com/patw0929/react-intl-tel-input/issues/252#issuecomment-458234735) which is called via ref.
This pull request is based on their workaround but without ref.

## Screenshots (if appropriate):

Before fix:
<img src="http://g.recordit.co/MaxgBmXN80.gif" />

After fix:
<img src="http://g.recordit.co/ofVLIKvoKh.gif" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
