### PR TITLE
Fix: invoke onPhoneNumberChange callback with formatted value on init instead of unformatted value from previous state

### DIFF
--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -711,7 +711,7 @@ class IntlTelInput extends Component {
       },
       () => {
         if (doNotify) {
-          this.notifyPhoneNumberChange(this.state.value);
+          this.notifyPhoneNumberChange(number);
         }
 
         this.unbindDocumentClick();


### PR DESCRIPTION
## Description

When using `formatOnInit` in conjunction with `onPhoneNumberChange`, a bug causes the latter callback to be invoked with a value from the not-yet-formatted previous state.

This change fixes this behavior and notifies the callback with the updated, formatted value.

I have tried to write two test cases (default and `formatOnInit=false`), but unfortunately, my knowledge of Enzyme is too limited 😥️ The behavior relies on libphonenumber-js-utils to be done loading, so the test cases must run after the deferred are resolved…

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
