### PR TITLE
Update flag when defaultCountry value is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+*This project is an instance of original project made by [Patrick Wang](https://github.com/patw0929).
+Because of the lack of activity on original repo, I have added some functionalities and published it on npmjs for my own personal use.
+Copyright (c) 2015-2019 [Patrick Wang](https://github.com/patw0929).*
+
 # React-Intl-Tel-Input
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)

--- a/README.md
+++ b/README.md
@@ -119,4 +119,3 @@ yarn run lint
 MIT
 
 Copyright (c) 2015-2019 patw.
-

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -163,6 +163,10 @@ class IntlTelInput extends Component {
     if (this.props.allowDropdown !== prevProps.allowDropdown) {
       this.allowDropdown = this.props.allowDropdown;
     }
+
+    if (this.props.defaultCountry !== prevProps.defaultCountry) {
+      this.updateFlagOnDefaultCountryChange(this.props.defaultCountry)
+    }
   }
 
   componentWillUnmount() {
@@ -170,6 +174,11 @@ class IntlTelInput extends Component {
     window.removeEventListener('scroll', this.handleWindowScroll);
     this.unbindDocumentClick();
   }
+
+  // Updates flag when value of defaultCountry props change
+  updateFlagOnDefaultCountryChange = (countryCode) => {
+    this.setFlag(countryCode, false)
+  };
 
   getTempCountry = countryCode => {
     if (countryCode === 'auto') {
@@ -211,7 +220,7 @@ class IntlTelInput extends Component {
   };
 
   // select the given flag, update the placeholder and the active list item
-  // Note: called from setInitialState, updateFlagFromNumber, selectListItem, setCountry
+  // Note: called from setInitialState, updateFlagFromNumber, selectListItem, setCountry, updateFlagOnDefaultCountryChange
   setFlag = (countryCode, isInit) => {
     const prevCountry =
       this.selectedCountryData && this.selectedCountryData.iso2
@@ -1244,6 +1253,8 @@ class IntlTelInput extends Component {
       this.autoCountryDeferred.resolve();
     }
   };
+
+
 
   render() {
     this.wrapperClass[this.props.containerClassName] = true;

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1254,8 +1254,6 @@ class IntlTelInput extends Component {
     }
   };
 
-
-
   render() {
     this.wrapperClass[this.props.containerClassName] = true;
     const inputClass = this.props.inputClassName;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds functionality of updating country flag when defaultCountry props value is updated after component is mounted.
## Description
Current version of the project doesn't support the functionality of updating flag when value passed in props *defaultCountry* is changed.
To support this functionality, I have added a function named *updateFlagOnDefaultCountryChange* which will pass the value of this.props.defaultCountry as CountryCode in *setFlag* function.

Event componentDidUpdate determines whether this function should be called or not based on current and previous value of props defaultCountry.

## Screenshots (if appropriate):
<!--- If possible, please attach the screenshots (you can use recordit.co to record as GIFs) --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
