### PR TITLE
Removed bash highlighting for npm/yarn commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ yarn run build
 
 To contribute to react-intl-tel-input, clone this repo locally and commit your code on a separate branch. Please write tests for your code, and run the linter before opening a pull-request:
 
-```bash
+```
 npm test
 npm run lint
 ```
 
 or
 
-```bash
+```
 yarn test
 yarn run lint
 ```


### PR DESCRIPTION

Fixes #293 
## Description
Removed bash highlighting for npm/yarn command in README 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have used ESLint & Prettier to follow the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
