### PR TITLE
fixed bug with pasting number over another number

### DIFF
--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1218,12 +1218,6 @@ class IntlTelInput extends Component {
     }
   };
 
-  handlePaste = e => {
-    if (e.clipboardData) {
-      this.updateFlagFromNumber(e.clipboardData.getData('Text'), false);
-    }
-  };
-
   changeHighlightCountry = (showDropdown, selectedIndex) => {
     this.setState({
       showDropdown,
@@ -1290,7 +1284,6 @@ class IntlTelInput extends Component {
           refCallback={this.setTelRef}
           handleInputChange={this.handleInputChange}
           handleOnBlur={this.handleOnBlur}
-          handlePaste={this.handlePaste}
           className={inputClass}
           disabled={this.state.disabled}
           readonly={this.state.readonly}

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -11,7 +11,6 @@ export default class TelInput extends Component {
     value: PropTypes.string,
     placeholder: PropTypes.string,
     handleInputChange: PropTypes.func,
-    handlePaste: PropTypes.func,
     handleOnBlur: PropTypes.func,
     autoFocus: PropTypes.bool,
     autoComplete: PropTypes.string,
@@ -50,12 +49,6 @@ export default class TelInput extends Component {
     this.setState({ hasFocus: true });
   };
 
-  handlePaste = e => {
-    if (typeof this.props.handlePaste === 'function') {
-      this.props.handlePaste(e);
-    }
-  };
-
   render() {
     return (
       <input
@@ -71,7 +64,6 @@ export default class TelInput extends Component {
         value={this.props.value}
         placeholder={this.props.placeholder}
         onChange={this.props.handleInputChange}
-        onPaste={this.handlePaste}
         onBlur={this.handleBlur}
         onFocus={this.handleFocus}
         autoFocus={this.props.autoFocus}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There were an issue with actions triggered on onChange and onPaste. Both of them were overlapping and causing multiple rerenders, but also error with concatenating numbers onPaste (instead of replacing). Only onChange was needed, so onPaste function and prop was deleted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly. **Functionality didn't change**
- [ ] I have added tests to cover my changes. **Tests failed to run even on master.**
- [ ] All new and existing tests passed. **Tests failed to run even on master.**
