### PR TITLE
Add optional onPhoneNumberFocus function

### DIFF
--- a/.storybook/stories/3.Playground/Playground.stories.js
+++ b/.storybook/stories/3.Playground/Playground.stories.js
@@ -35,6 +35,7 @@ storiesOf('Documentation', module)
       preferredCountries={array('preferredCountries', defaultProps.preferredCountries)}
       onPhoneNumberChange={action('onPhoneNumberChange')}
       onPhoneNumberBlur={action('onPhoneNumberBlur')}
+      onPhoneNumberFocus={action('onPhoneNumberFocus')}
       onSelectFlag={action('onSelectFlag')}
       disabled={boolean('disabled', defaultProps.disabled)}
       placeholder={text('placeholder', defaultProps.placeholder)}

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -840,6 +840,23 @@ class IntlTelInput extends Component {
     }
   };
 
+  handleOnFocus = e => {
+    if (typeof this.props.onPhoneNumberFocus === 'function') {
+      const value = this.state.value;
+      const fullNumber = this.formatFullNumber(value);
+      const isValid = this.isValidNumber(fullNumber);
+
+      this.props.onPhoneNumberFocus(
+        isValid,
+        value,
+        this.selectedCountryData,
+        fullNumber,
+        this.getExtension(value),
+        e
+      );
+    }
+  };
+
   bindDocumentClick = () => {
     this.isOpening = true;
     document
@@ -1293,6 +1310,7 @@ class IntlTelInput extends Component {
           refCallback={this.setTelRef}
           handleInputChange={this.handleInputChange}
           handleOnBlur={this.handleOnBlur}
+          handleOnFocus={this.handleOnFocus}
           className={inputClass}
           disabled={this.state.disabled}
           readonly={this.state.readonly}
@@ -1367,6 +1385,8 @@ IntlTelInput.propTypes = {
   onPhoneNumberChange: PropTypes.func,
   /** Optional validation callback function. It returns validation status, input box value and selected country data. */
   onPhoneNumberBlur: PropTypes.func,
+  /** Optional validation callback function. It returns validation status, input box value and selected country data. */
+  onPhoneNumberFocus: PropTypes.func,
   /** Allow main app to do things when a country is selected. */
   onSelectFlag: PropTypes.func,
   /** Disable this component. */
@@ -1430,6 +1450,7 @@ IntlTelInput.defaultProps = {
   preferredCountries: ['us', 'gb'],
   onPhoneNumberChange: null,
   onPhoneNumberBlur: null,
+  onPhoneNumberFocus: null,
   onSelectFlag: null,
   disabled: false,
   autoFocus: false,

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -12,6 +12,7 @@ export default class TelInput extends Component {
     placeholder: PropTypes.string,
     handleInputChange: PropTypes.func,
     handleOnBlur: PropTypes.func,
+    handleOnFocus: PropTypes.func,
     autoFocus: PropTypes.bool,
     autoComplete: PropTypes.string,
     inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -45,8 +46,12 @@ export default class TelInput extends Component {
     }
   };
 
-  handleFocus = () => {
+  handleFocus = e => {
     this.setState({ hasFocus: true });
+
+    if (typeof this.props.handleOnFocus === 'function') {
+      this.props.handleOnFocus(e);
+    }
   };
 
   render() {

--- a/src/components/__tests__/TelInput.test.js
+++ b/src/components/__tests__/TelInput.test.js
@@ -242,31 +242,39 @@ describe('TelInput', function() {
     expect(subject.state().value).toBe('');
   });
 
-  it('onPhoneNumberBlur', () => {
-    let expected = '';
-    const onPhoneNumberBlur = (
-      isValid,
-      newNumber,
-      countryData,
-      fullNumber,
-      ext,
-      event
-    ) => {
-      const { type } = event;
+  const testOnPhoneNumberEvent = ({ property, eventType }) =>
+    it(`${property}`, () => {
+      let expected = '';
+      const onPhoneNumberEvent = (
+        isValid,
+        newNumber,
+        countryData,
+        fullNumber,
+        ext,
+        event
+      ) => {
+        const { type } = event;
 
-      expected = `${isValid},${newNumber},${
-        countryData.iso2
-      },${fullNumber},${ext},${type}`;
-    };
+        expected = `${isValid},${newNumber},${
+          countryData.iso2
+        },${fullNumber},${ext},${type}`;
+      };
 
-    this.params.onPhoneNumberBlur = onPhoneNumberBlur;
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+      this.params[property] = onPhoneNumberEvent;
+      const subject = this.makeSubject();
+      const inputComponent = subject.find(TelInput);
 
-    inputComponent.simulate('change', { target: { value: '+886911222333' } });
-    inputComponent.simulate('blur');
-    expect(expected).toBe('true,+886911222333,tw,+886 911 222 333,null,blur');
-  });
+      inputComponent.simulate('change', { target: { value: '+886911222333' } });
+      inputComponent.simulate(eventType);
+      expect(expected).toBe(
+        `true,+886911222333,tw,+886 911 222 333,null,${eventType}`
+      );
+    });
+
+  [
+    { property: 'onPhoneNumberBlur', eventType: 'blur' },
+    { property: 'onPhoneNumberFocus', eventType: 'focus' },
+  ].forEach(testOnPhoneNumberEvent);
 
   it('should has empty value with false nationalMode, false autoHideDialCode and false separateDialCode', () => {
     this.params = {


### PR DESCRIPTION
Added optional `onPhoneNumberFocus` function, similar to `onPhoneNumberBlur`.

## Description
Added `onPhoneNumberFocus` because it's not possible to extended `onFocus` in `telInputProps` property due to `onFocus` being overwritten in `src/components/TelInput.js`. There is an open PR addressing the same thing in #239, but it has been stale for some time and lack tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [x] I have used ESLint & Prettier to follow the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
