### PR TITLE
Bug fix: Bypass formatNumber if user is deleting

### DIFF
--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1205,7 +1205,10 @@ class IntlTelInput extends Component {
   // or udpate the state and notify change if component is uncontrolled
   handleInputChange = e => {
     let cursorPosition = e.target.selectionStart;
+    // previous value is pre formatted value
     const previousValue = e.target.value;
+    // prior value is existing state value/ before update
+    const priorValue = this.state.value;
     const previousStringBeforeCursor =
       previousValue === ''
         ? previousValue

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1210,8 +1210,13 @@ class IntlTelInput extends Component {
       previousValue === ''
         ? previousValue
         : previousValue.substring(0, cursorPosition);
+
+    // Don't format if user is deleting chars
+    const formattedValue = previousValue.length < priorValue.length
+      ? previousValue
+      : this.formatNumber(e.target.value);
     const value = this.props.format
-      ? this.formatNumber(e.target.value)
+      ? formattedValue
       : e.target.value;
 
     cursorPosition = utils.getCursorPositionAfterFormating(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://www.loom.com/share/a4d1e5295b0341ecb3da4a2c019e32b4

## Description
** Pls see the video.  This PR potentially fixes the following bug:

For some localities (I've only identified Russia), when a user deletes numbers `window.intlTelInputUtils.formatNumber` behaves incorrectly.

window.intlTelInputUtils.formatNumber('8 (444) 444-44-4', 'ru', 2)  ==> "8 (844) 444-44-44"
window.intlTelInputUtils.formatNumber('8 (844) 444-44-4', 'ru', 2)  ==> "8 (884) 444-44-44"
window.intlTelInputUtils.formatNumber('8 (884) 444-44-4', 'ru', 2)  ==> "8 (888) 444-44-44"
window.intlTelInputUtils.formatNumber('8 (888) 44-44-4', 'ru', 2)  ==> "8 (888) 844-44-44"
window.intlTelInputUtils.formatNumber('8 (888) 84-44-4', 'ru', 2)  ==> "8 (888) 884-44-44"

. . . and so on, until all digits are '8'.

## Screenshots (if appropriate):
See video above

## Types of changes
Adds a check on IntlTelInput -> If user has deleted from input val, do not perform a format.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
