### PR TITLE
Extract Flagbox

### DIFF
--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import utils from './utils';
 
+import FlagBox from './FlagBox'
+
 function partial(fn, ...args) {
   return fn.bind(fn, ...args);
 }
@@ -79,38 +81,23 @@ export default class CountryList extends Component {
         preferred: isPreferred,
       };
       const countryClass = classNames(countryClassObj);
-      const keyPrefix = isPreferred ? 'pref-' : '';
-
+      const onMouseOverOrFocus = this.props.isMobile ? () => {} : this.handleMouseOver
+      const keyPrefix = isPreferred ? 'pref-' : ''
+ 
       return (
-        <li
-          key={`${keyPrefix}${country.iso2}`}
-          className={countryClass}
-          data-dial-code={country.dialCode}
-          data-country-code={country.iso2}
-          onMouseOver={this.props.isMobile ? null : this.handleMouseOver}
+        <FlagBox
+          key={`${keyPrefix}${country.iso2}`} 
+          dialCode={country.dialCode}
+          isoCode={country.iso2}
+          name={country.name}
+          onMouseOver={onMouseOverOrFocus}
           onClick={partial(this.setFlag, country.iso2)}
-        >
-          <div
-            ref={selectedFlag => {
-              this.selectedFlag = selectedFlag;
-            }}
-            className="flag-box"
-          >
-            <div
-              ref={selectedFlagInner => {
-                this.selectedFlagInner = selectedFlagInner;
-              }}
-              className={`iti-flag ${country.iso2}`}
-            />
-          </div>
-
-          <span className="country-name">{country.name}</span>
-          <span className="dial-code">
-+
-            {country.dialCode}
-          </span>
-        </li>
-      );
+          onFocus={onMouseOverOrFocus}
+          flagRef={selectedFlag => { this.selectedFlag = selectedFlag }}
+          innerFlagRef={selectedFlagInner => { this.selectedFlagInner = selectedFlagInner }}
+          countryClass={countryClass}
+        />
+      )
     });
   };
 
@@ -123,13 +110,12 @@ export default class CountryList extends Component {
   };
 
   render() {
+    const { preferredCountries, countries, showDropdown } = this.props
     let options = '';
-    const preferredCountries = this.props.preferredCountries;
     let preferredOptions = null;
-    const countries = this.props.countries;
     const className = classNames({
       'country-list': true,
-      hide: !this.props.showDropdown,
+      hide: !showDropdown,
     });
     let divider = null;
 

--- a/src/components/FlagBox.js
+++ b/src/components/FlagBox.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const FlagBox = ({
+  dialCode,
+  isoCode,
+  name,
+  onMouseOver,
+  onFocus,
+  onClick,
+  flagRef,
+  innerFlagRef,
+  countryClass,
+}) => (
+  <li
+    className={countryClass}
+    data-dial-code={dialCode}
+    data-country-code={isoCode}
+    onMouseOver={onMouseOver}
+    onFocus={onFocus}
+    onClick={onClick}
+  >
+    <div
+      ref={flagRef}
+      className="flag-box"
+    >
+      <div
+        ref={innerFlagRef}
+        className={`iti-flag ${isoCode}`}
+      />
+    </div>
+
+    <span className="country-name">{name}</span>
+    <span className="dial-code">
+      {`+ ${dialCode}`}
+    </span>
+  </li>
+) 
+
+FlagBox.propTypes = {
+  dialCode: PropTypes.string.isRequired,
+  isoCode: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onMouseOver: PropTypes.func,
+  onFocus: PropTypes.func,
+  onClick: PropTypes.func,
+  flagRef: PropTypes.func,
+  innerFlagRef: PropTypes.func,
+  countryClass: PropTypes.string.isRequired,
+}
+
+FlagBox.defaultProps = {
+  onFocus: () => {},
+  onMouseOver: () => {},
+  onClick: () => {},
+}
+
+export default FlagBox


### PR DESCRIPTION
# Preamble

As part of removing the extraneous use of Webpack in #314 , I noticed that the usage of `scss` in styling forces the project to be bundled so that a style loader can take care of the style. Before `scss` can be replaced by something more appropriate for the module context (versus having a bundled webapp), there's a few refactors that can be done to simplify the logic, lighten the code and speed up later development.

## Description

This breaks out the `FlagBox` component our of `CountryList` to separate concerns and extract code that is purely presentational in nature from containers that are more involved in business logic. As far as the outside API is concerned, this is a no-op, but it'll benefit developer velocity and further work.

## Types of changes
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have used ESLint & Prettier to follow the code style of this project.
- ~[ ] I have updated the documentation accordingly.~
- ~[ ] I have added tests to cover my changes.~
- [x] All new and existing tests passed.

## QA

I went through `storybook` and interacted with the component before and after the changes, and compared with the latest `master`. No differences there. Also interacted with the `CountryList` using keyboard-only to make sure that it didn't regress.

Test suites passing + the above quality checks make this change a high-confidence move.
