### PR TITLE
Refactoring around `CountryList`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "libphonenumber-js-utils": "^8.10.2",
     "prop-types": "^15.6.1",
     "react-style-proptype": "^3.0.0",
+    "styled-components": "^4.0.0",
     "underscore.deferred": "^0.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "main": "dist/main.js",
   "peerDependencies": {
     "react": ">15.4.2 <17.0.0",
-    "react-dom": ">15.4.2 <17.0.0"
+    "react-dom": ">15.4.2 <17.0.0",
+    "styled-components": "^4.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "libphonenumber-js-utils": "^8.10.2",
     "prop-types": "^15.6.1",
     "react-style-proptype": "^3.0.0",
-    "styled-components": "^4.0.0",
     "underscore.deferred": "^0.4.0"
   },
   "devDependencies": {
@@ -92,6 +92,7 @@
     "sass-loader": "^7.1.0",
     "sinon": "^1.17.4",
     "storybook-addon-react-docgen": "^1.0.4",
+    "styled-components": "^4.0.0",
     "style-loader": "^0.23.1",
     "uglifyjs-webpack-plugin": "^2.0.1",
     "url-loader": "^1.1.2",

--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -1,3 +1,4 @@
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -23,7 +24,7 @@ export default class CountryList extends Component {
     const shouldUpdate = !utils.shallowEquals(this.props, nextProps);
 
     if (shouldUpdate && nextProps.showDropdown) {
-      this.listElement.setAttribute('class', 'country-list v-hide');
+      this.listElement.classList.add('v-hide');
       this.setDropdownPosition();
     }
 
@@ -31,8 +32,7 @@ export default class CountryList extends Component {
   }
 
   setDropdownPosition = () => {
-    utils.removeClass(this.listElement, 'hide');
-
+    this.listElement.classList.remove('hide')
     const inputTop = this.props.inputTop;
     const windowTop =
       window.pageYOffset !== undefined
@@ -60,7 +60,7 @@ export default class CountryList extends Component {
         : '';
 
     this.listElement.style.top = cssTop;
-    this.listElement.setAttribute('class', 'country-list');
+    this.listElement.classList.remove('v-hide')
   };
 
   appendListItem = (countries, isPreferred = false) => {

--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -5,10 +5,6 @@ import utils from './utils';
 
 import FlagBox from './FlagBox';
 
-function partial(fn, ...args) {
-  return fn.bind(fn, ...args);
-}
-
 export default class CountryList extends Component {
   static propTypes = {
     setFlag: PropTypes.func,
@@ -66,10 +62,6 @@ export default class CountryList extends Component {
     this.listElement.setAttribute('class', 'country-list');
   };
 
-  setFlag = iso2 => {
-    this.props.setFlag(iso2);
-  };
-
   appendListItem = (countries, isPreferred = false) => {
     const preferredCountriesCount = this.props.preferredCountries.length;
 
@@ -93,7 +85,7 @@ export default class CountryList extends Component {
           isoCode={country.iso2}
           name={country.name}
           onMouseOver={onMouseOverOrFocus}
-          onClick={partial(this.setFlag, country.iso2)}
+          onClick={() => this.props.setFlag(country.iso2)}
           onFocus={onMouseOverOrFocus}
           flagRef={selectedFlag => {
             this.selectedFlag = selectedFlag;
@@ -117,8 +109,7 @@ export default class CountryList extends Component {
 
   render() {
     const { preferredCountries, countries, showDropdown } = this.props;
-    const className = classNames({
-      'country-list': true,
+    const className = classNames('country-list', {
       hide: !showDropdown,
     });
 

--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import utils from './utils';
 
-import FlagBox from './FlagBox'
+import FlagBox from './FlagBox';
 
 function partial(fn, ...args) {
   return fn.bind(fn, ...args);
@@ -81,23 +81,29 @@ export default class CountryList extends Component {
         preferred: isPreferred,
       };
       const countryClass = classNames(countryClassObj);
-      const onMouseOverOrFocus = this.props.isMobile ? () => {} : this.handleMouseOver
-      const keyPrefix = isPreferred ? 'pref-' : ''
- 
+      const onMouseOverOrFocus = this.props.isMobile
+        ? () => {}
+        : this.handleMouseOver;
+      const keyPrefix = isPreferred ? 'pref-' : '';
+
       return (
         <FlagBox
-          key={`${keyPrefix}${country.iso2}`} 
+          key={`${keyPrefix}${country.iso2}`}
           dialCode={country.dialCode}
           isoCode={country.iso2}
           name={country.name}
           onMouseOver={onMouseOverOrFocus}
           onClick={partial(this.setFlag, country.iso2)}
           onFocus={onMouseOverOrFocus}
-          flagRef={selectedFlag => { this.selectedFlag = selectedFlag }}
-          innerFlagRef={selectedFlagInner => { this.selectedFlagInner = selectedFlagInner }}
+          flagRef={selectedFlag => {
+            this.selectedFlag = selectedFlag;
+          }}
+          innerFlagRef={selectedFlagInner => {
+            this.selectedFlagInner = selectedFlagInner;
+          }}
           countryClass={countryClass}
         />
-      )
+      );
     });
   };
 
@@ -110,12 +116,12 @@ export default class CountryList extends Component {
   };
 
   render() {
-    const { preferredCountries, countries, showDropdown } = this.props
+    const { preferredCountries, countries, showDropdown } = this.props;
     const className = classNames({
       'country-list': true,
       hide: !showDropdown,
     });
-    
+
     const divider = <div className="divider" />;
     const preferredOptions = this.appendListItem(preferredCountries, true);
     const allOptions = this.appendListItem(countries);

--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import utils from './utils';
 
 import FlagBox from './FlagBox';
+import { Divider } from './CountryList.styles'
 
 export default class CountryList extends Component {
   static propTypes = {
@@ -113,7 +114,6 @@ export default class CountryList extends Component {
       hide: !showDropdown,
     });
 
-    const divider = <div className="divider" />;
     const preferredOptions = this.appendListItem(preferredCountries, true);
     const allOptions = this.appendListItem(countries);
 
@@ -125,7 +125,7 @@ export default class CountryList extends Component {
         className={className}
       >
         {preferredOptions}
-        {preferredCountries.length > 0 ? divider : null}
+        {preferredCountries.length > 0 ? <Divider /> : null}
         {allOptions}
       </ul>
     );

--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -111,20 +111,14 @@ export default class CountryList extends Component {
 
   render() {
     const { preferredCountries, countries, showDropdown } = this.props
-    let options = '';
-    let preferredOptions = null;
     const className = classNames({
       'country-list': true,
       hide: !showDropdown,
     });
-    let divider = null;
-
-    if (preferredCountries.length) {
-      preferredOptions = this.appendListItem(preferredCountries, true);
-      divider = <div className="divider" />;
-    }
-
-    options = this.appendListItem(countries);
+    
+    const divider = <div className="divider" />;
+    const preferredOptions = this.appendListItem(preferredCountries, true);
+    const allOptions = this.appendListItem(countries);
 
     return (
       <ul
@@ -134,8 +128,8 @@ export default class CountryList extends Component {
         className={className}
       >
         {preferredOptions}
-        {divider}
-        {options}
+        {preferredCountries.length > 0 ? divider : null}
+        {allOptions}
       </ul>
     );
   }

--- a/src/components/CountryList.styles.js
+++ b/src/components/CountryList.styles.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+// eslint-disable-next-line import/prefer-default-export
+export const Divider = styled.div`
+    padding-bottom: 5px;
+    margin-bottom: 5px;
+    border-bottom: $borderWidth solid $greyBorder;
+`

--- a/src/components/FlagBox.js
+++ b/src/components/FlagBox.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const FlagBox = ({
   dialCode,
@@ -20,22 +20,14 @@ const FlagBox = ({
     onFocus={onFocus}
     onClick={onClick}
   >
-    <div
-      ref={flagRef}
-      className="flag-box"
-    >
-      <div
-        ref={innerFlagRef}
-        className={`iti-flag ${isoCode}`}
-      />
+    <div ref={flagRef} className="flag-box">
+      <div ref={innerFlagRef} className={`iti-flag ${isoCode}`} />
     </div>
 
     <span className="country-name">{name}</span>
-    <span className="dial-code">
-      {`+ ${dialCode}`}
-    </span>
+    <span className="dial-code">{`+ ${dialCode}`}</span>
   </li>
-) 
+);
 
 FlagBox.propTypes = {
   dialCode: PropTypes.string.isRequired,
@@ -47,12 +39,12 @@ FlagBox.propTypes = {
   flagRef: PropTypes.func,
   innerFlagRef: PropTypes.func,
   countryClass: PropTypes.string.isRequired,
-}
+};
 
 FlagBox.defaultProps = {
   onFocus: () => {},
   onMouseOver: () => {},
   onClick: () => {},
-}
+};
 
-export default FlagBox
+export default FlagBox;

--- a/src/components/FlagDropDown.js
+++ b/src/components/FlagDropDown.js
@@ -4,7 +4,11 @@ import classNames from 'classnames';
 import CountryList from './CountryList';
 import RootModal from './RootModal';
 
-import { DownArrow, UpArrow, SelectedFlagPopoverButton } from './FlagDropDown.styles'
+import {
+  DownArrow,
+  UpArrow,
+  SelectedFlagPopoverButton,
+} from './FlagDropDown.styles';
 
 export default class FlagDropDown extends Component {
   static propTypes = {
@@ -33,31 +37,20 @@ export default class FlagDropDown extends Component {
 
     return separateDialCode ? (
       <div className="selected-dial-code">{dialCode}</div>
-    ) : (
-      ''
-    );
+    ) : null;
   };
 
   genArrow = () => {
     const { allowDropdown, showDropdown } = this.props;
-    const arrow = showDropdown ? <UpArrow /> : <DownArrow />
+    const arrow = showDropdown ? <UpArrow /> : <DownArrow />;
 
-    
-    return allowDropdown ? arrow : null
+    return allowDropdown ? arrow : null;
   };
 
-  genFlagClassName = () => {
-    const { countryCode } = this.props;
-    const flagClassObj = {
-      'iti-flag': true,
-    };
-
-    if (countryCode) {
-      flagClassObj[countryCode] = true;
-    }
-
-    return classNames(flagClassObj);
-  };
+  genFlagClassName = () =>
+    classNames('iti-flag', {
+      [this.props.countryCode]: !!this.props.countryCode,
+    });
 
   genCountryList = () => {
     const {

--- a/src/components/FlagDropDown.js
+++ b/src/components/FlagDropDown.js
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 import CountryList from './CountryList';
 import RootModal from './RootModal';
 
+import { DownArrow, UpArrow, SelectedFlagPopoverButton } from './FlagDropDown.styles'
+
 export default class FlagDropDown extends Component {
   static propTypes = {
     allowDropdown: PropTypes.bool,
@@ -38,12 +40,10 @@ export default class FlagDropDown extends Component {
 
   genArrow = () => {
     const { allowDropdown, showDropdown } = this.props;
-    const arrowClass = classNames({
-      'iti-arrow': true,
-      up: showDropdown,
-    });
+    const arrow = showDropdown ? <UpArrow /> : <DownArrow />
 
-    return allowDropdown ? <div className={arrowClass} /> : '';
+    
+    return allowDropdown ? arrow : null
   };
 
   genFlagClassName = () => {
@@ -106,7 +106,7 @@ export default class FlagDropDown extends Component {
 
     return (
       <div ref={refCallback} className="flag-container">
-        <div
+        <SelectedFlagPopoverButton
           className="selected-flag"
           tabIndex={allowDropdown ? '0' : ''}
           onClick={clickSelectedFlag}
@@ -116,7 +116,7 @@ export default class FlagDropDown extends Component {
           <div className={this.genFlagClassName()} />
           {this.genSelectedDialCode()}
           {this.genArrow()}
-        </div>
+        </SelectedFlagPopoverButton>
         {dropdownContainer && showDropdown ? (
           <RootModal>{this.genCountryList()}</RootModal>
         ) : (

--- a/src/components/FlagDropDown.styles.js
+++ b/src/components/FlagDropDown.styles.js
@@ -1,24 +1,24 @@
-import styled from 'styled-components'
+import styled from 'styled-components';
 
 const ArrowBase = styled.div`
-    font-size: 6px;
-    margin-left: 5px;
-`
+  font-size: 6px;
+  margin-left: 5px;
+`;
 
 export const UpArrow = styled(ArrowBase)`
-    &:after {
-        content: "▲";
-    }
-`
+  &:after {
+    content: '▲';
+  }
+`;
 
 export const DownArrow = styled(ArrowBase)`
-    &:after {
-        content: "▼";
-    }
-`
+  &:after {
+    content: '▼';
+  }
+`;
 
 export const SelectedFlagPopoverButton = styled.div`
-   display: flex;
-   justify-content: center;
-   align-items: center;
-`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/FlagDropDown.styles.js
+++ b/src/components/FlagDropDown.styles.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+const ArrowBase = styled.div`
+    font-size: 6px;
+    margin-left: 5px;
+`
+
+export const UpArrow = styled(ArrowBase)`
+    &:after {
+        content: "▲";
+    }
+`
+
+export const DownArrow = styled(ArrowBase)`
+    &:after {
+        content: "▼";
+    }
+`
+
+export const SelectedFlagPopoverButton = styled.div`
+   display: flex;
+   justify-content: center;
+   align-items: center;
+`

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -165,7 +165,7 @@ class IntlTelInput extends Component {
     }
 
     if (this.props.defaultCountry !== prevProps.defaultCountry) {
-      this.updateFlagOnDefaultCountryChange(this.props.defaultCountry)
+      this.updateFlagOnDefaultCountryChange(this.props.defaultCountry);
     }
   }
 
@@ -176,8 +176,8 @@ class IntlTelInput extends Component {
   }
 
   // Updates flag when value of defaultCountry props change
-  updateFlagOnDefaultCountryChange = (countryCode) => {
-    this.setFlag(countryCode, false)
+  updateFlagOnDefaultCountryChange = countryCode => {
+    this.setFlag(countryCode, false);
   };
 
   getTempCountry = countryCode => {
@@ -1215,12 +1215,11 @@ class IntlTelInput extends Component {
         : previousValue.substring(0, cursorPosition);
 
     // Don't format if user is deleting chars
-    const formattedValue = previousValue.length < priorValue.length
-      ? previousValue
-      : this.formatNumber(e.target.value);
-    const value = this.props.format
-      ? formattedValue
-      : e.target.value;
+    const formattedValue =
+      previousValue.length < priorValue.length
+        ? previousValue
+        : this.formatNumber(e.target.value);
+    const value = this.props.format ? formattedValue : e.target.value;
 
     cursorPosition = utils.getCursorPositionAfterFormating(
       previousStringBeforeCursor,

--- a/src/components/__tests__/FlagDropDown.test.js
+++ b/src/components/__tests__/FlagDropDown.test.js
@@ -72,7 +72,10 @@ describe('FlagDropDown', function() {
     expect(
       subject.find(CountryList).find('.country-list.hide').length
     ).toBeTruthy();
-    flagComponent.find('.selected-flag').last().simulate('click');
+    flagComponent
+      .find('.selected-flag')
+      .last()
+      .simulate('click');
 
     subject.update();
     expect(

--- a/src/components/__tests__/FlagDropDown.test.js
+++ b/src/components/__tests__/FlagDropDown.test.js
@@ -72,7 +72,7 @@ describe('FlagDropDown', function() {
     expect(
       subject.find(CountryList).find('.country-list.hide').length
     ).toBeTruthy();
-    flagComponent.find('.selected-flag').simulate('click');
+    flagComponent.find('.selected-flag').last().simulate('click');
 
     subject.update();
     expect(

--- a/src/components/__tests__/TelInput.test.js
+++ b/src/components/__tests__/TelInput.test.js
@@ -467,7 +467,7 @@ describe('TelInput', function() {
 
     it('should set "expanded" class to wrapper only when flags are open', () => {
       const subject = this.makeSubject();
-      const flagComponent = subject.find(FlagDropDown).find('.selected-flag');
+      const flagComponent = subject.find(FlagDropDown).find('.selected-flag').last();
 
       flagComponent.simulate('click');
       expect(subject.instance().wrapperClass.expanded).toBe(true);

--- a/src/components/__tests__/TelInput.test.js
+++ b/src/components/__tests__/TelInput.test.js
@@ -467,7 +467,10 @@ describe('TelInput', function() {
 
     it('should set "expanded" class to wrapper only when flags are open', () => {
       const subject = this.makeSubject();
-      const flagComponent = subject.find(FlagDropDown).find('.selected-flag').last();
+      const flagComponent = subject
+        .find(FlagDropDown)
+        .find('.selected-flag')
+        .last();
 
       flagComponent.simulate('click');
       expect(subject.instance().wrapperClass.expanded).toBe(true);

--- a/src/components/__tests__/utils.test.js
+++ b/src/components/__tests__/utils.test.js
@@ -156,17 +156,6 @@ describe('utils', () => {
     expect(element.classList.contains('efg')).toBeTruthy();
   });
 
-  it('removeClass', () => {
-    const DEFAULT_HTML = `<html><body>
-      <div class="abc cde">test</div>
-    </body></html>`;
-    const doc = jsdom.jsdom(DEFAULT_HTML);
-    const element = doc.querySelector('.abc');
-
-    utils.removeClass(element, 'abc');
-
-    expect(element.classList.contains('abc')).toBeFalsy();
-  });
 
   it('findIndex', () => {
     let array = [];

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -188,16 +188,6 @@ export default {
     }
   },
 
-  removeClass(el, className) {
-    if (el.classList) {
-      el.classList.remove(className);
-    } else if (this.hasClass(el, className)) {
-      const reg = new RegExp(`(\\s|^)${className}(\\s|$)`);
-
-      el.className = el.className.replace(reg, ' ');
-    }
-  },
-
   findIndex(items, predicate) {
     let index = -1;
 

--- a/src/styles/intlTelInput.scss
+++ b/src/styles/intlTelInput.scss
@@ -11,15 +11,10 @@ $flagPadding: 8px !default;
 // assumed to be the border width of the input, which we do not control
 $borderWidth: 1px !default;
 
-$arrowHeight: 4px !default;
-$arrowWidth: 6px !default;
-$triangleBorder: 3px !default;
-$arrowPadding: 6px !default;
-$arrowColor: #555 !default;
-
 $inputPadding: 6px !default;
 $selectedFlagWidth: $flagWidth + (2 * $flagPadding) !default;
-$selectedFlagArrowWidth: $flagWidth + $flagPadding + $arrowWidth + (2 * $arrowPadding) !default;
+// 18px previously arrow width and padding, 6px ea.
+$selectedFlagArrowWidth: $flagWidth + $flagPadding + 18px !default;
 $selectedFlagArrowDialCodeWidth: $selectedFlagArrowWidth + $flagPadding !default;
 
 // enough space for them to click off to close
@@ -90,26 +85,6 @@ $mobilePopupMargin: 30px;
     // this must be full-height both for the hover highlight, and to push down the
     // dropdown so it appears below the input
     height: 100%;
-
-    .iti-arrow {
-      position: absolute;
-      // split the difference between the flag and the arrow height to verically center
-      top: 50%;
-      margin-top: -1 * ($arrowHeight / 2);
-      right: $arrowPadding;
-
-      // css triangle
-      width: 0;
-      height: 0;
-      border-left: $triangleBorder solid transparent;
-      border-right: $triangleBorder solid transparent;
-      border-top: $arrowHeight solid $arrowColor;
-
-      &.up {
-        border-top: none;
-        border-bottom: $arrowHeight solid $arrowColor;
-      }
-    }
   }
 
   // the dropdown

--- a/src/styles/intlTelInput.scss
+++ b/src/styles/intlTelInput.scss
@@ -129,13 +129,6 @@ $mobilePopupMargin: 30px;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
 
-    // the divider below the preferred countries
-    .divider {
-      padding-bottom: 5px;
-      margin-bottom: 5px;
-      border-bottom: $borderWidth solid $greyBorder;
-    }
-
     // each country item in dropdown (we must have separate class to differentiate from dividers)
     .country {
       // Note: decided not to use line-height here for alignment because it causes issues e.g. large font-sizes will overlap, and also looks bad if one country overflows onto 2 lines

--- a/src/styles/intlTelInput.scss
+++ b/src/styles/intlTelInput.scss
@@ -90,15 +90,6 @@ $mobilePopupMargin: 30px;
     // this must be full-height both for the hover highlight, and to push down the
     // dropdown so it appears below the input
     height: 100%;
-    padding: 0 0 0 $flagPadding;
-
-    // vertically center the flag
-    .iti-flag {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      margin: auto;
-    }
 
     .iti-arrow {
       position: absolute;

--- a/yarn.lock
+++ b/yarn.lock
@@ -985,6 +985,18 @@
   dependencies:
     "@emotion/memoize" "^0.6.6"
 
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.7.tgz#803449993f436f9a6c67752251ea3fc492a1044c"
+  integrity sha512-OPkKzUeiid0vEKjZqnGcy2mzxjIlCffin+L2C02pdz/bVlt5zZZE2VzO0D3XOPnH0NEeF21QNKSXiZphjr4xiQ==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
 "@emotion/memoize@^0.6.6":
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
@@ -1030,6 +1042,11 @@
 "@emotion/unitless@^0.6.7":
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@emotion/utils@^0.8.2":
   version "0.8.2"
@@ -2417,6 +2434,16 @@ babel-plugin-react-docgen@^2.0.0, babel-plugin-react-docgen@^2.0.2:
     react-docgen "^3.0.0"
     recast "^0.14.7"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
+  integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -2452,6 +2479,11 @@ babel-plugin-syntax-export-extensions@^6.8.0:
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -3421,6 +3453,11 @@ camelcase@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
 
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
+
 caniuse-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
@@ -4095,6 +4132,11 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -4169,6 +4211,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -7148,6 +7199,11 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-what@^3.3.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.6.0.tgz#458f7895d4b2aec4484e2a274dbb8a618eebea04"
+  integrity sha512-2rMAWmuDACWgcy5Cp4eDXHRf4GlNjXKp3e/0etFzE5HZhCgPw8u5zeKDyLIUmtE2GP9mGK3jS7jvXYFc6qk/ZA==
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -8235,6 +8291,11 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -8256,6 +8317,13 @@ meow@^3.3.0, meow@^3.7.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
+
+merge-anything@^2.2.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.4.tgz#6226b2ac3d3d3fc5fb9e8d23aa400df25f98fdf0"
+  integrity sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==
+  dependencies:
+    is-what "^3.3.1"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -10218,6 +10286,11 @@ react-inspector@^2.3.0:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
+react-is@^16.6.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
+
 react-is@^16.6.1, react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
@@ -11655,6 +11728,25 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+styled-components@^4.0.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
+  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.1.tgz#3186595d047ab0df813d213e51c8b94e0b9010f2"
@@ -11662,6 +11754,16 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 supports-color@5.4.0:
   version "5.4.0"


### PR DESCRIPTION
# Preamble

See #315.

## Description
This trims code around the `CountryList` quite a bit and starts the move from scss to `styled-components`. It also starts to tackle the binding of style <> functionality around classes by extract the style from some of them so that their functional role can be refactored away separately.

From the outside perspective, this is a no-op.
## Types of changes
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have used ESLint & Prettier to follow the code style of this project.
- ~[ ] I have updated the documentation accordingly.~
- ~[ ] I have added tests to cover my changes.~
- [x] All new and existing tests passed.

Did cursory QA in Chrome and Firefox to ensure that no regression seeped in, nothing to report.