### PR TITLE
Removing SCSS import from components

### DIFF
--- a/.storybook/stories/1.GettingStarted/GettingStarted.stories.js
+++ b/.storybook/stories/1.GettingStarted/GettingStarted.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import IntlTelInput from '../../../src/components/IntlTelInput';
+import '../../../src/styles/intlTelInput.scss'
 
 storiesOf('Documentation', module)
   .addParameters({ options: { showAddonPanel: false } })

--- a/.storybook/stories/2.Props/Props.stories.js
+++ b/.storybook/stories/2.Props/Props.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 
 import IntlTelInput from '../../../src/components/IntlTelInput';
-
+import '../../../src/styles/intlTelInput.scss'
 storiesOf('Documentation', module)
   .addParameters({ options: { showAddonPanel: false } })
   .add('Props', withInfo({ inline: true, source: false })(() => <IntlTelInput />));

--- a/.storybook/stories/3.Playground/Playground.stories.js
+++ b/.storybook/stories/3.Playground/Playground.stories.js
@@ -5,7 +5,7 @@ import { withInfo } from '@storybook/addon-info';
 import { withKnobs, text, boolean, array } from '@storybook/addon-knobs/react';
 
 import IntlTelInput from '../../../src/components/IntlTelInput';
-
+import '../../../src/styles/intlTelInput.scss'
 const { defaultProps } = IntlTelInput;
 
 storiesOf('Documentation', module)

--- a/.storybook/stories/5.CustomStyle/CustomStyle.stories.js
+++ b/.storybook/stories/5.CustomStyle/CustomStyle.stories.js
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs/react';
 
 import IntlTelInput from '../../../src/components/IntlTelInput';
-
+import '../../../src/styles/intlTelInput.scss'
 storiesOf('Usage', module)
   .addDecorator(withKnobs)
   .add('Custom Style', withInfo({ inline: true, source: false, propTables: null })(() =>

--- a/.storybook/stories/6.GeoIP/GeoIP.stories.js
+++ b/.storybook/stories/6.GeoIP/GeoIP.stories.js
@@ -4,7 +4,7 @@ import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 
 import IntlTelInput from '../../../src/components/IntlTelInput';
-
+import '../../../src/styles/intlTelInput.scss'
 import { lookup } from '../../helpers/helpers';
 
 storiesOf('Usage', module)

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -8,7 +8,6 @@ import FlagDropDown from './FlagDropDown';
 import TelInput from './TelInput';
 import utils from './utils';
 import { KEYS } from './constants';
-import '../styles/intlTelInput.scss';
 
 const mobileUserAgentRegexp = /Android.+Mobile|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
 


### PR DESCRIPTION
## Description
In order to allow for users to use their own stylesheets (or to just use the sample provided one), we can take off any SASS imports from within the component. This is something the old Webpack setup used to do.

It's reasonable to assume that the consumer's React apps will have a Webpack-like system, and that they will use something like `node-sass` to handle proper stylesheet loading.