### PR TITLE
Cleaning up ESLint / prettier configs and uniting them

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  extends: ['eslint-config-airbnb', 'prettier'],
+    extends: ['eslint-config-airbnb', "plugin:prettier/recommended"],
+  plugins: ['react', 'import', 'security', 'prettier'],
   parser: 'babel-eslint',
   env: {
     browser: true,
@@ -8,12 +9,14 @@ module.exports = {
     jest: true,
   },
   rules: {
+    'prettier/prettier': 'error',
     'prefer-destructuring': 'off',
     'jsx-a11y/click-events-have-key-events': 'off',
     'jsx-a11y/no-noninteractive-element-interactions': 'off',
     'jsx-a11y/no-autofocus': 'off',
     'jsx-a11y/no-noninteractive-tabindex': 'off',
     'jsx-a11y/anchor-has-content': 'off',
+    'jsx-a11y/no-static-element-interactions': 'off',
     'react/destructuring-assignment': 'off',
     'react/jsx-no-bind': 'error',
     'react/no-multi-comp': 'off',
@@ -23,14 +26,8 @@ module.exports = {
       'ForInStatement',
       'WithStatement',
     ],
-    'newline-after-var': ['error', 'always'],
-    'newline-before-return': 'error',
     'comma-dangle': ['error', 'always-multiline'], // https://github.com/airbnb/javascript/commit/788208295469e19b806c06e01095dc8ba1b6cdc9
-    indent: ['error', 2, { SwitchCase: 1 }],
-    'no-console': 0,
-    'no-alert': 0,
     'no-underscore-dangle': 'off',
-    'max-len': 'off',
     'react/require-default-props': 'off',
     'react/jsx-curly-spacing': 'off',
     'arrow-body-style': 'off',
@@ -48,9 +45,6 @@ module.exports = {
     ],
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.jsx'] }],
     'react/no-string-refs': 'off',
-    'arrow-parens': 'off',
-    'jsx-a11y/no-static-element-interactions': 'off',
-    'react/prefer-stateless-function': 'off',
     'no-param-reassign': 'off',
     'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'import/no-unresolved': [
@@ -62,7 +56,6 @@ module.exports = {
       'error',
       {
         devDependencies: [
-          'scripts/**/*.js',
           'test/**', // tape, common npm pattern
           'tests/**', // also common npm pattern
           'spec/**', // mocha, rspec-like pattern
@@ -80,30 +73,9 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
-    indent: [
-      'error',
-      2,
-      {
-        SwitchCase: 1,
-        VariableDeclarator: 1,
-        outerIIFEBody: 1,
-        MemberExpression: 1,
-        // CallExpression: {
-        // parameters: null,
-        // },
-        FunctionDeclaration: {
-          parameters: 1,
-          body: 1,
-        },
-        FunctionExpression: {
-          parameters: 1,
-          body: 1,
-        },
-      },
-    ],
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
   },
-  plugins: ['react', 'import', 'security'],
+  
   globals: {
     __DEVELOPMENT__: true,
     __CLIENT__: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,26 +1,21 @@
-module.exports = {  
-  "collectCoverageFrom": [
-    "src/**/*.js",
-    "!**/__mocks__/**",
-    "!**/__tests__/**",
-    "!.storybook",
+module.exports = {
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!**/__mocks__/**',
+    '!**/__tests__/**',
+    '!.storybook',
   ],
-  "setupFiles": [
-    "<rootDir>/config/jest/setup.js",
-  ],
-  "setupTestFrameworkScriptFile": "<rootDir>/config/jest/setupTestFramework.js",
-  "testPathIgnorePatterns": [
-    "<rootDir>[/\\\\](build|docs|node_modules)[/\\\\]",
-  ],
-  "testEnvironment": "jsdom",
-  "testURL": "http://localhost",
-  "transform": {
-    "^.+\\.(js|jsx)$": "<rootDir>/config/jest/transform.js",
-    "^.+\\.(scss|css)$": "<rootDir>/config/jest/cssTransform.js",
-    "^(?!.*\\.(js|jsx|css|scss|json)$)": "<rootDir>/config/jest/fileTransform.js",
+  setupFiles: ['<rootDir>/config/jest/setup.js'],
+  setupTestFrameworkScriptFile: '<rootDir>/config/jest/setupTestFramework.js',
+  testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['<rootDir>[/\\\\](build|docs|node_modules)[/\\\\]'],
+  testRegex: '/__tests__/.*\\.(test|spec)\\.js$',
+  testURL: 'http://localhost',
+  transform: {
+    '^(?!.*\\.(js|jsx|css|scss|json)$)':
+      '<rootDir>/config/jest/fileTransform.js',
+    '^.+\\.(js|jsx)$': '<rootDir>/config/jest/transform.js',
+    '^.+\\.(scss|css)$': '<rootDir>/config/jest/cssTransform.js',
   },
-  "transformIgnorePatterns": [
-    "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$",
-  ],
-  "testRegex": "/__tests__/.*\\.(test|spec)\\.js$",
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
 }

--- a/package.json
+++ b/package.json
@@ -70,10 +70,11 @@
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "~17.1.0",
     "eslint-config-airbnb-base": "~13.1.0",
-    "eslint-config-prettier": "^3.0.1",
+    "eslint-config-prettier": "^6.10.0",
     "eslint-loader": "^2.1.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.11.0",
     "eslint-plugin-security": "^1.3.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
@@ -92,6 +93,7 @@
     "packwatch": "^1.0.0",
     "postcss-safe-parser": "^4.0.1",
     "prettier": "^1.14.2",
+    "prettier-eslint": "^9.0.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-hot-loader": "^1.3.0",
@@ -114,11 +116,9 @@
     "start": "start-storybook -p 4000 -c .storybook",
     "deploy": "storybook-to-ghpages --ci",
     "lint-staged": "lint-staged",
-    "lint": "yarn run eslint",
-    "eslint": "eslint src",
+    "lint": "eslint src *.js",
     "coverage": "yarn run test -- --coverage",
     "coveralls": "cross-env NODE_ENV=development cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "prettier:all": "prettier --write 'src/components/**/*.js' 'config/**/*.js' 'scripts/**/*.js'",
     "test": "jest src",
     "test:watch": "jest src --watchAll --coverage",
     "footprint": "yarn build && yarn packwatch",
@@ -137,11 +137,13 @@
     }
   },
   "husky": {
-      "hooks": {
-          "pre-commit": "lint-staged",
-          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-  }},
+    "hooks": {
+      "pre-commit": "lint-staged",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
   "prettier": {
+    "semi": false,
     "printWidth": 80,
     "singleQuote": true,
     "trailingComma": "es5"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "clean": "rimraf dist",
     "start": "start-storybook -p 4000 -c .storybook",
     "deploy": "storybook-to-ghpages --ci",
-    "lint-staged": "lint-staged",
     "lint": "eslint src *.js",
     "coverage": "yarn run test -- --coverage",
     "coveralls": "cross-env NODE_ENV=development cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
@@ -127,9 +126,7 @@
   "lint-staged": {
     "linters": {
       "*.js": [
-        "yarn prettier --write",
-        "yarn run eslint -- --fix",
-        "git add"
+        "yarn eslint --"
       ],
       "src/**/*.js": [
         "yarn run test -- --bail --findRelatedTests"

--- a/src/components/AllCountries.js
+++ b/src/components/AllCountries.js
@@ -341,9 +341,9 @@ const defaultCountriesData = [
   ['Zambia', 'zm', '260'],
   ['Zimbabwe', 'zw', '263'],
   ['Åland Islands', 'ax', '358', 1],
-];
+]
 
-let countries;
+let countries
 
 function _formatCountriesData(countriesData) {
   return countriesData.map(country => ({
@@ -352,26 +352,26 @@ function _formatCountriesData(countriesData) {
     dialCode: country[2],
     priority: country[3] || 0,
     areaCodes: country[4] || null,
-  }));
+  }))
 }
 
 function initialize(externalCountriesList) {
   countries = _formatCountriesData(
     externalCountriesList || defaultCountriesData
-  );
+  )
 }
 
 function getCountries() {
   if (!countries) {
-    initialize();
+    initialize()
   }
 
-  return countries;
+  return countries
 }
 
 const AllCountries = {
   initialize,
   getCountries,
-};
+}
 
-export default AllCountries;
+export default AllCountries

--- a/src/components/CountryList.js
+++ b/src/components/CountryList.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import utils from './utils';
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import utils from './utils'
 
-import FlagBox from './FlagBox';
+import FlagBox from './FlagBox'
 
 export default class CountryList extends Component {
   static propTypes = {
@@ -16,66 +16,66 @@ export default class CountryList extends Component {
     changeHighlightCountry: PropTypes.func,
     showDropdown: PropTypes.bool,
     isMobile: PropTypes.bool,
-  };
+  }
 
   shouldComponentUpdate(nextProps) {
-    const shouldUpdate = !utils.shallowEquals(this.props, nextProps);
+    const shouldUpdate = !utils.shallowEquals(this.props, nextProps)
 
     if (shouldUpdate && nextProps.showDropdown) {
-      this.listElement.classList.add('v-hide');
-      this.setDropdownPosition();
+      this.listElement.classList.add('v-hide')
+      this.setDropdownPosition()
     }
 
-    return shouldUpdate;
+    return shouldUpdate
   }
 
   setDropdownPosition = () => {
-    this.listElement.classList.remove('hide');
-    const inputTop = this.props.inputTop;
+    this.listElement.classList.remove('hide')
+    const inputTop = this.props.inputTop
     const windowTop =
       window.pageYOffset !== undefined
         ? window.pageYOffset
         : (
-          document.documentElement ||
+            document.documentElement ||
             document.body.parentNode ||
             document.body
-        ).scrollTop;
+          ).scrollTop
     const windowHeight =
       window.innerHeight ||
       document.documentElement.clientHeight ||
-      document.body.clientHeight;
-    const inputOuterHeight = this.props.inputOuterHeight;
-    const countryListOuterHeight = utils.getOuterHeight(this.listElement);
+      document.body.clientHeight
+    const inputOuterHeight = this.props.inputOuterHeight
+    const countryListOuterHeight = utils.getOuterHeight(this.listElement)
     const dropdownFitsBelow =
       inputTop + inputOuterHeight + countryListOuterHeight <
-      windowTop + windowHeight;
-    const dropdownFitsAbove = inputTop - countryListOuterHeight > windowTop;
+      windowTop + windowHeight
+    const dropdownFitsAbove = inputTop - countryListOuterHeight > windowTop
 
     // dropdownHeight - 1 for border
     const cssTop =
       !dropdownFitsBelow && dropdownFitsAbove
         ? `-${countryListOuterHeight - 1}px`
-        : '';
+        : ''
 
-    this.listElement.style.top = cssTop;
-    this.listElement.classList.remove('v-hide');
-  };
+    this.listElement.style.top = cssTop
+    this.listElement.classList.remove('v-hide')
+  }
 
   appendListItem = (countries, isPreferred = false) => {
-    const preferredCountriesCount = this.props.preferredCountries.length;
+    const preferredCountriesCount = this.props.preferredCountries.length
 
     return countries.map((country, index) => {
-      const actualIndex = isPreferred ? index : index + preferredCountriesCount;
+      const actualIndex = isPreferred ? index : index + preferredCountriesCount
       const countryClassObj = {
         country: true,
         highlight: this.props.highlightedCountry === actualIndex,
         preferred: isPreferred,
-      };
-      const countryClass = classNames(countryClassObj);
+      }
+      const countryClass = classNames(countryClassObj)
       const onMouseOverOrFocus = this.props.isMobile
         ? () => {}
-        : this.handleMouseOver;
-      const keyPrefix = isPreferred ? 'pref-' : '';
+        : this.handleMouseOver
+      const keyPrefix = isPreferred ? 'pref-' : ''
 
       return (
         <FlagBox
@@ -87,39 +87,39 @@ export default class CountryList extends Component {
           onClick={() => this.props.setFlag(country.iso2)}
           onFocus={onMouseOverOrFocus}
           flagRef={selectedFlag => {
-            this.selectedFlag = selectedFlag;
+            this.selectedFlag = selectedFlag
           }}
           innerFlagRef={selectedFlagInner => {
-            this.selectedFlagInner = selectedFlagInner;
+            this.selectedFlagInner = selectedFlagInner
           }}
           countryClass={countryClass}
         />
-      );
-    });
-  };
+      )
+    })
+  }
 
   handleMouseOver = e => {
     if (e.currentTarget.getAttribute('class').indexOf('country') > -1) {
-      const selectedIndex = utils.retrieveLiIndex(e.currentTarget);
+      const selectedIndex = utils.retrieveLiIndex(e.currentTarget)
 
-      this.props.changeHighlightCountry(true, selectedIndex);
+      this.props.changeHighlightCountry(true, selectedIndex)
     }
-  };
+  }
 
   render() {
-    const { preferredCountries, countries, showDropdown } = this.props;
+    const { preferredCountries, countries, showDropdown } = this.props
     const className = classNames('country-list', {
       hide: !showDropdown,
-    });
+    })
 
-    const preferredOptions = this.appendListItem(preferredCountries, true);
-    const allOptions = this.appendListItem(countries);
-    const divider = <div className="divider" />;
+    const preferredOptions = this.appendListItem(preferredCountries, true)
+    const allOptions = this.appendListItem(countries)
+    const divider = <div className="divider" />
 
     return (
       <ul
         ref={listElement => {
-          this.listElement = listElement;
+          this.listElement = listElement
         }}
         className={className}
       >
@@ -127,6 +127,6 @@ export default class CountryList extends Component {
         {preferredCountries.length > 0 ? divider : null}
         {allOptions}
       </ul>
-    );
+    )
   }
 }

--- a/src/components/FlagBox.js
+++ b/src/components/FlagBox.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const FlagBox = ({
   dialCode,
@@ -27,7 +27,7 @@ const FlagBox = ({
     <span className="country-name">{name}</span>
     <span className="dial-code">{`+ ${dialCode}`}</span>
   </li>
-);
+)
 
 FlagBox.propTypes = {
   dialCode: PropTypes.string.isRequired,
@@ -39,12 +39,12 @@ FlagBox.propTypes = {
   flagRef: PropTypes.func,
   innerFlagRef: PropTypes.func,
   countryClass: PropTypes.string.isRequired,
-};
+}
 
 FlagBox.defaultProps = {
   onFocus: () => {},
   onMouseOver: () => {},
   onClick: () => {},
-};
+}
 
-export default FlagBox;
+export default FlagBox

--- a/src/components/FlagDropDown.js
+++ b/src/components/FlagDropDown.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import CountryList from './CountryList';
-import RootModal from './RootModal';
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import CountryList from './CountryList'
+import RootModal from './RootModal'
 
 export default class FlagDropDown extends Component {
   static propTypes = {
@@ -24,27 +24,27 @@ export default class FlagDropDown extends Component {
     changeHighlightCountry: PropTypes.func,
     titleTip: PropTypes.string,
     refCallback: PropTypes.func.isRequired,
-  };
+  }
 
   genSelectedDialCode = () => {
-    const { separateDialCode, dialCode } = this.props;
+    const { separateDialCode, dialCode } = this.props
 
     return separateDialCode ? (
       <div className="selected-dial-code">{dialCode}</div>
-    ) : null;
-  };
+    ) : null
+  }
 
   genArrow = () => {
-    const { allowDropdown, showDropdown } = this.props;
-    const arrowClasses = classNames('arrow', showDropdown ? 'up' : 'down');
+    const { allowDropdown, showDropdown } = this.props
+    const arrowClasses = classNames('arrow', showDropdown ? 'up' : 'down')
 
-    return allowDropdown ? <div className={arrowClasses} /> : null;
-  };
+    return allowDropdown ? <div className={arrowClasses} /> : null
+  }
 
   genFlagClassName = () =>
     classNames('iti-flag', {
       [this.props.countryCode]: !!this.props.countryCode,
-    });
+    })
 
   genCountryList = () => {
     const {
@@ -59,12 +59,12 @@ export default class FlagDropDown extends Component {
       preferredCountries,
       highlightedCountry,
       changeHighlightCountry,
-    } = this.props;
+    } = this.props
 
     return (
       <CountryList
         ref={countryList => {
-          this.countryList = countryList;
+          this.countryList = countryList
         }}
         dropdownContainer={dropdownContainer}
         isMobile={isMobile}
@@ -77,8 +77,8 @@ export default class FlagDropDown extends Component {
         highlightedCountry={highlightedCountry}
         changeHighlightCountry={changeHighlightCountry}
       />
-    );
-  };
+    )
+  }
 
   render() {
     const {
@@ -89,7 +89,7 @@ export default class FlagDropDown extends Component {
       titleTip,
       dropdownContainer,
       showDropdown,
-    } = this.props;
+    } = this.props
 
     return (
       <div ref={refCallback} className="flag-container">
@@ -110,6 +110,6 @@ export default class FlagDropDown extends Component {
           this.genCountryList()
         )}
       </div>
-    );
+    )
   }
 }

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1,19 +1,19 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import _ from 'underscore.deferred';
-import StylePropTypes from 'react-style-proptype';
-import AllCountries from './AllCountries';
-import FlagDropDown from './FlagDropDown';
-import TelInput from './TelInput';
-import utils from './utils';
-import { KEYS } from './constants';
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import _ from 'underscore.deferred'
+import StylePropTypes from 'react-style-proptype'
+import AllCountries from './AllCountries'
+import FlagDropDown from './FlagDropDown'
+import TelInput from './TelInput'
+import utils from './utils'
+import { KEYS } from './constants'
 
-const mobileUserAgentRegexp = /Android.+Mobile|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+const mobileUserAgentRegexp = /Android.+Mobile|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
 
 class IntlTelInput extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
-    let newState = null;
+    let newState = null
 
     if (
       typeof nextProps.value !== 'undefined' &&
@@ -21,43 +21,43 @@ class IntlTelInput extends Component {
     ) {
       newState = {
         value: nextProps.value,
-      };
+      }
     }
 
     if (prevState.disabled !== nextProps.disabled) {
       newState = {
         disabled: nextProps.disabled,
-      };
+      }
     }
 
-    return newState;
+    return newState
   }
 
   constructor(props) {
-    super(props);
+    super(props)
 
-    this.wrapperClass = {};
+    this.wrapperClass = {}
 
-    this.autoCountry = '';
-    this.tempCountry = '';
-    this.startedLoadingAutoCountry = false;
+    this.autoCountry = ''
+    this.tempCountry = ''
+    this.startedLoadingAutoCountry = false
 
-    this.deferreds = [];
-    this.autoCountryDeferred = new _.Deferred();
-    this.utilsScriptDeferred = new _.Deferred();
+    this.deferreds = []
+    this.autoCountryDeferred = new _.Deferred()
+    this.utilsScriptDeferred = new _.Deferred()
 
-    this.isOpening = false;
+    this.isOpening = false
     this.isMobile =
       typeof navigator !== 'undefined' &&
-      mobileUserAgentRegexp.test(navigator.userAgent);
-    this.preferredCountries = [];
-    this.countries = [];
-    this.countryCodes = {};
+      mobileUserAgentRegexp.test(navigator.userAgent)
+    this.preferredCountries = []
+    this.countries = []
+    this.countryCodes = {}
 
-    this.windowLoaded = false;
+    this.windowLoaded = false
 
-    this.query = '';
-    this.selectedCountryData = {};
+    this.query = ''
+    this.selectedCountryData = {}
 
     this.state = {
       showDropdown: false,
@@ -72,108 +72,108 @@ class IntlTelInput extends Component {
       countryCode: 'us',
       dialCode: '',
       cursorPosition: (props.value || props.defaultValue).length,
-    };
+    }
   }
 
   componentDidMount() {
-    this.autoHideDialCode = this.props.autoHideDialCode;
-    this.allowDropdown = this.props.allowDropdown;
-    this.nationalMode = this.props.nationalMode;
-    this.dropdownContainer = '';
+    this.autoHideDialCode = this.props.autoHideDialCode
+    this.allowDropdown = this.props.allowDropdown
+    this.nationalMode = this.props.nationalMode
+    this.dropdownContainer = ''
 
     // if in nationalMode, disable options relating to dial codes
     if (this.nationalMode) {
-      this.autoHideDialCode = false;
+      this.autoHideDialCode = false
     }
 
     // if separateDialCode then doesn't make sense to
     // A) insert dial code into input (autoHideDialCode), and
     // B) display national numbers (because we're displaying the country dial code next to them)
     if (this.props.separateDialCode) {
-      this.autoHideDialCode = false;
-      this.nationalMode = false;
+      this.autoHideDialCode = false
+      this.nationalMode = false
       // let's force this for now for simplicity - we can support this later if need be
-      this.allowDropdown = true;
+      this.allowDropdown = true
     }
 
-    this.processCountryData.call(this);
-    this.tempCountry = this.getTempCountry(this.props.defaultCountry);
+    this.processCountryData.call(this)
+    this.tempCountry = this.getTempCountry(this.props.defaultCountry)
 
     if (document.readyState === 'complete') {
-      this.windowLoaded = true;
+      this.windowLoaded = true
     } else {
       window.addEventListener('load', () => {
-        this.windowLoaded = true;
-      });
+        this.windowLoaded = true
+      })
     }
 
     // generate the markup
-    this.generateMarkup();
+    this.generateMarkup()
     // set the initial state of the input value and the selected flag
-    this.setInitialState();
+    this.setInitialState()
     // utils script, and auto country
-    this.initRequests();
+    this.initRequests()
 
-    this.deferreds.push(this.autoCountryDeferred.promise());
-    this.deferreds.push(this.utilsScriptDeferred.promise());
+    this.deferreds.push(this.autoCountryDeferred.promise())
+    this.deferreds.push(this.utilsScriptDeferred.promise())
 
     _.when(this.deferreds).done(() => {
-      this.setInitialState();
-    });
+      this.setInitialState()
+    })
 
-    document.addEventListener('keydown', this.handleDocumentKeyDown);
+    document.addEventListener('keydown', this.handleDocumentKeyDown)
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     if (nextState.showDropdown) {
-      document.addEventListener('keydown', this.handleDocumentKeyDown);
-      this.bindDocumentClick();
+      document.addEventListener('keydown', this.handleDocumentKeyDown)
+      this.bindDocumentClick()
     } else {
-      document.removeEventListener('keydown', this.handleDocumentKeyDown);
-      this.unbindDocumentClick();
+      document.removeEventListener('keydown', this.handleDocumentKeyDown)
+      this.unbindDocumentClick()
     }
 
-    return true;
+    return true
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.value !== prevProps.value) {
-      this.updateFlagFromNumber(this.props.value);
+      this.updateFlagFromNumber(this.props.value)
     }
 
     if (
       typeof this.props.customPlaceholder === 'function' &&
       prevProps.customPlaceholder !== this.props.customPlaceholder
     ) {
-      this.updatePlaceholder(this.props);
+      this.updatePlaceholder(this.props)
     }
 
     if (this.props.allowDropdown !== prevProps.allowDropdown) {
-      this.allowDropdown = this.props.allowDropdown;
+      this.allowDropdown = this.props.allowDropdown
     }
 
     if (this.props.defaultCountry !== prevProps.defaultCountry) {
-      this.updateFlagOnDefaultCountryChange(this.props.defaultCountry);
+      this.updateFlagOnDefaultCountryChange(this.props.defaultCountry)
     }
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleDocumentKeyDown);
-    window.removeEventListener('scroll', this.handleWindowScroll);
-    this.unbindDocumentClick();
+    document.removeEventListener('keydown', this.handleDocumentKeyDown)
+    window.removeEventListener('scroll', this.handleWindowScroll)
+    this.unbindDocumentClick()
   }
 
   // Updates flag when value of defaultCountry props change
   updateFlagOnDefaultCountryChange = countryCode => {
-    this.setFlag(countryCode, false);
-  };
+    this.setFlag(countryCode, false)
+  }
 
   getTempCountry = countryCode => {
     if (countryCode === 'auto') {
-      return 'auto';
+      return 'auto'
     }
 
-    let countryData = utils.getCountryData(this.countries, countryCode);
+    let countryData = utils.getCountryData(this.countries, countryCode)
 
     // check if country is available in the list
     if (!countryData.iso2) {
@@ -181,31 +181,31 @@ class IntlTelInput extends Component {
         countryData = utils.getCountryData(
           this.countries,
           this.props.preferredCountries[0]
-        );
+        )
       } else {
-        countryData = AllCountries.getCountries()[0];
+        countryData = AllCountries.getCountries()[0]
       }
     }
 
-    return countryData.iso2;
-  };
+    return countryData.iso2
+  }
 
   // set the input value and update the flag
   // NOTE: preventFormat arg is for public method
   setNumber = (number, preventFormat) => {
     // we must update the flag first, which updates this.selectedCountryData,
     // which is used for formatting the number before displaying it
-    this.updateFlagFromNumber(number);
-    this.updateValFromNumber(number, !preventFormat);
-  };
+    this.updateFlagFromNumber(number)
+    this.updateValFromNumber(number, !preventFormat)
+  }
 
   setFlagDropdownRef = ref => {
-    this.flagDropDown = ref;
-  };
+    this.flagDropDown = ref
+  }
 
   setTelRef = ref => {
-    this.tel = ref;
-  };
+    this.tel = ref
+  }
 
   // select the given flag, update the placeholder and the active list item
   // Note: called from setInitialState, updateFlagFromNumber, selectListItem, setCountry, updateFlagOnDefaultCountryChange
@@ -213,73 +213,71 @@ class IntlTelInput extends Component {
     const prevCountry =
       this.selectedCountryData && this.selectedCountryData.iso2
         ? this.selectedCountryData
-        : {};
+        : {}
 
     // do this first as it will throw an error and stop if countryCode is invalid
     this.selectedCountryData = countryCode
       ? utils.getCountryData(
-        this.countries,
-        countryCode,
-        false,
-        false,
-        this.props.noCountryDataHandler
-      )
-      : {};
+          this.countries,
+          countryCode,
+          false,
+          false,
+          this.props.noCountryDataHandler
+        )
+      : {}
 
     // update the defaultCountry - we only need the iso2 from now on, so just store that
     if (this.selectedCountryData.iso2) {
-      this.defaultCountry = this.selectedCountryData.iso2;
+      this.defaultCountry = this.selectedCountryData.iso2
     }
 
     // update the selected country's title attribute
     const title = countryCode
-      ? `${this.selectedCountryData.name}: +${
-        this.selectedCountryData.dialCode
-      }`
-      : 'Unknown';
+      ? `${this.selectedCountryData.name}: +${this.selectedCountryData.dialCode}`
+      : 'Unknown'
 
-    let dialCode = this.state.dialCode; // eslint-disable-line react/no-access-state-in-setstate
+    let dialCode = this.state.dialCode // eslint-disable-line react/no-access-state-in-setstate
 
     if (this.props.separateDialCode) {
       dialCode = this.selectedCountryData.dialCode
         ? `+${this.selectedCountryData.dialCode}`
-        : '';
+        : ''
 
       if (prevCountry.dialCode) {
-        delete this.wrapperClass[`iti-sdc-${prevCountry.dialCode.length + 1}`];
+        delete this.wrapperClass[`iti-sdc-${prevCountry.dialCode.length + 1}`]
       }
 
       if (dialCode) {
-        this.wrapperClass[`iti-sdc-${dialCode.length}`] = true;
+        this.wrapperClass[`iti-sdc-${dialCode.length}`] = true
       }
     }
 
-    let selectedIndex = 0;
+    let selectedIndex = 0
 
     if (countryCode && countryCode !== 'auto') {
       selectedIndex = utils.findIndex(
         this.preferredCountries,
         country => country.iso2 === countryCode
-      );
+      )
 
       if (selectedIndex === -1) {
         selectedIndex = utils.findIndex(
           this.countries,
           country => country.iso2 === countryCode
-        );
-        if (selectedIndex === -1) selectedIndex = 0;
-        selectedIndex += this.preferredCountries.length;
+        )
+        if (selectedIndex === -1) selectedIndex = 0
+        selectedIndex += this.preferredCountries.length
       }
     }
 
     if (this.tel && this.state.showDropdown) {
-      this.tel.focus();
+      this.tel.focus()
     }
 
     const newNumber = this.updateDialCode(
       this.selectedCountryData.dialCode,
       !isInit
-    );
+    )
 
     this.setState(
       {
@@ -292,10 +290,10 @@ class IntlTelInput extends Component {
       },
       () => {
         // and the input's placeholder
-        this.updatePlaceholder(this.props);
+        this.updatePlaceholder(this.props)
 
         // update the active list item
-        this.wrapperClass.active = false;
+        this.wrapperClass.active = false
 
         // on change flag, trigger a custom event
         // Allow Main app to do things when a country is selected
@@ -304,21 +302,21 @@ class IntlTelInput extends Component {
           prevCountry.iso2 !== countryCode &&
           typeof this.props.onSelectFlag === 'function'
         ) {
-          const currentNumber = this.state.value;
+          const currentNumber = this.state.value
 
-          const fullNumber = this.formatFullNumber(currentNumber);
-          const isValid = this.isValidNumber(fullNumber);
+          const fullNumber = this.formatFullNumber(currentNumber)
+          const isValid = this.isValidNumber(fullNumber)
 
           this.props.onSelectFlag(
             currentNumber,
             this.selectedCountryData,
             fullNumber,
             isValid
-          );
+          )
         }
       }
-    );
-  };
+    )
+  }
 
   // get the extension from the current number
   getExtension = number => {
@@ -326,11 +324,11 @@ class IntlTelInput extends Component {
       return window.intlTelInputUtils.getExtension(
         this.getFullNumber(number),
         this.selectedCountryData.iso2
-      );
+      )
     }
 
-    return '';
-  };
+    return ''
+  }
 
   // format the number to the given format
   getNumber = (number, format) => {
@@ -339,72 +337,72 @@ class IntlTelInput extends Component {
         this.getFullNumber(number),
         this.selectedCountryData.iso2,
         format
-      );
+      )
     }
 
-    return '';
-  };
+    return ''
+  }
 
   // get the input val, adding the dial code if separateDialCode is enabled
   getFullNumber = number => {
     const prefix = this.props.separateDialCode
       ? `+${this.selectedCountryData.dialCode}`
-      : '';
+      : ''
 
-    return prefix + number;
-  };
+    return prefix + number
+  }
 
   // try and extract a valid international dial code from a full telephone number
   // Note: returns the raw string inc plus character and any whitespace/dots etc
   getDialCode = number => {
-    let dialCode = '';
+    let dialCode = ''
 
     // only interested in international numbers (starting with a plus)
     if (number.charAt(0) === '+') {
-      let numericChars = '';
+      let numericChars = ''
 
       // iterate over chars
       for (let i = 0, max = number.length; i < max; i++) {
-        const c = number.charAt(i);
+        const c = number.charAt(i)
 
         // if char is number
         if (utils.isNumeric(c)) {
-          numericChars += c;
+          numericChars += c
           // if current numericChars make a valid dial code
           if (this.countryCodes[numericChars]) {
             // store the actual raw string (useful for matching later)
-            dialCode = number.substr(0, i + 1);
+            dialCode = number.substr(0, i + 1)
           }
           // longest dial code is 4 chars
           if (numericChars.length === 4) {
-            break;
+            break
           }
         }
       }
     }
 
-    return dialCode;
-  };
+    return dialCode
+  }
 
   // check if the given number contains an unknown area code from
   // the North American Numbering Plan i.e. the only dialCode that
   // could be extracted was +1 but the actual number's length is >=4
   isUnknownNanp = (number, dialCode) => {
-    return dialCode === '+1' && utils.getNumeric(number).length >= 4;
-  };
+    return dialCode === '+1' && utils.getNumeric(number).length >= 4
+  }
 
   // add a country code to countryCodes
   addCountryCode = (countryCodes, iso2, dialCode, priority) => {
     if (!(dialCode in countryCodes)) {
-      countryCodes[dialCode] = [];
+      countryCodes[dialCode] = []
     }
 
-    const index = priority || 0;
+    const index = priority || 0
 
-    countryCodes[dialCode][index] = iso2;
+    countryCodes[dialCode][index] = iso2
 
-    return countryCodes;
-  };
+    return countryCodes
+  }
 
   processAllCountries = () => {
     if (this.props.onlyCountries.length) {
@@ -414,7 +412,7 @@ class IntlTelInput extends Component {
         inArray =>
           // if country is in array
           inArray !== -1
-      );
+      )
     } else if (this.props.excludeCountries.length) {
       // process excludeCountries option
       this.filterCountries(
@@ -422,19 +420,19 @@ class IntlTelInput extends Component {
         inArray =>
           // if country is not in array
           inArray === -1
-      );
+      )
     } else {
-      this.countries = AllCountries.getCountries();
+      this.countries = AllCountries.getCountries()
     }
-  };
+  }
 
   // process the countryCodes map
   processCountryCodes = () => {
-    this.countryCodes = {};
+    this.countryCodes = {}
     for (let i = 0; i < this.countries.length; i++) {
-      const c = this.countries[i];
+      const c = this.countries[i]
 
-      this.addCountryCode(this.countryCodes, c.iso2, c.dialCode, c.priority);
+      this.addCountryCode(this.countryCodes, c.iso2, c.dialCode, c.priority)
       // area codes
       if (c.areaCodes) {
         for (let j = 0; j < c.areaCodes.length; j++) {
@@ -443,48 +441,48 @@ class IntlTelInput extends Component {
             this.countryCodes,
             c.iso2,
             c.dialCode + c.areaCodes[j]
-          );
+          )
         }
       }
     }
-  };
+  }
 
   // process preferred countries - iterate through the preferences,
   // fetching the country data for each one
   processPreferredCountries = () => {
-    this.preferredCountries = [];
+    this.preferredCountries = []
     for (let i = 0, max = this.props.preferredCountries.length; i < max; i++) {
-      const countryCode = this.props.preferredCountries[i].toLowerCase();
+      const countryCode = this.props.preferredCountries[i].toLowerCase()
       const countryData = utils.getCountryData(
         this.countries,
         countryCode,
         true
-      );
+      )
 
       if (countryData) {
-        this.preferredCountries.push(countryData);
+        this.preferredCountries.push(countryData)
       }
     }
-  };
+  }
 
   // set the initial state of the input value and the selected flag
   setInitialState = () => {
-    const val = this.props.value || this.props.defaultValue || '';
+    const val = this.props.value || this.props.defaultValue || ''
 
     // if we already have a dial code we can go ahead and set the flag, else fall back to default
     if (this.getDialCode(val)) {
-      this.updateFlagFromNumber(val, true);
+      this.updateFlagFromNumber(val, true)
     } else if (this.tempCountry !== 'auto') {
       // see if we should select a flag
       if (this.tempCountry) {
-        this.setFlag(this.tempCountry, true);
+        this.setFlag(this.tempCountry, true)
       } else {
         // no dial code and no tempCountry, so default to first in list
         this.defaultCountry = this.preferredCountries.length
           ? this.preferredCountries[0].iso2
-          : this.countries[0].iso2;
+          : this.countries[0].iso2
         if (!val) {
-          this.setFlag(this.defaultCountry, true);
+          this.setFlag(this.defaultCountry, true)
         }
       }
       // if empty and no nationalMode and no autoHideDialCode then insert the default dial code
@@ -496,43 +494,43 @@ class IntlTelInput extends Component {
       ) {
         this.setState({
           value: `+${this.selectedCountryData.dialCode}`,
-        });
+        })
       }
     }
 
-    const doNotify = true;
+    const doNotify = true
 
     // NOTE: if tempCountry is set to auto, that will be handled separately
     // format
     if (val) {
-      this.updateValFromNumber(val, this.props.formatOnInit, doNotify);
+      this.updateValFromNumber(val, this.props.formatOnInit, doNotify)
     }
-  };
+  }
 
   initRequests = () => {
     import('libphonenumber-js-utils')
       .then(() => {
-        this.loadUtils();
-        this.utilsScriptDeferred.resolve();
+        this.loadUtils()
+        this.utilsScriptDeferred.resolve()
       })
-      .catch(() => 'An error occurred while loading the component');
+      .catch(() => 'An error occurred while loading the component')
 
     if (this.tempCountry === 'auto') {
-      this.loadAutoCountry();
+      this.loadAutoCountry()
     } else {
-      this.autoCountryDeferred.resolve();
+      this.autoCountryDeferred.resolve()
     }
-  };
+  }
 
   loadAutoCountry = () => {
     // check for localStorage
     const lsAutoCountry =
       window.localStorage !== undefined
         ? window.localStorage.getItem('itiAutoCountry')
-        : '';
+        : ''
 
     if (lsAutoCountry) {
-      this.autoCountry = lsAutoCountry;
+      this.autoCountry = lsAutoCountry
     }
 
     // 3 options:
@@ -540,16 +538,16 @@ class IntlTelInput extends Component {
     // 2) not already started loading (start)
     // 3) already started loading (do nothing - just wait for loading callback to fire)
     if (this.autoCountry) {
-      this.autoCountryLoaded();
+      this.autoCountryLoaded()
     } else if (!this.startedLoadingAutoCountry) {
       // don't do this twice!
-      this.startedLoadingAutoCountry = true;
+      this.startedLoadingAutoCountry = true
 
       if (typeof this.props.geoIpLookup === 'function') {
         this.props.geoIpLookup(countryCode => {
-          this.autoCountry = countryCode.toLowerCase();
+          this.autoCountry = countryCode.toLowerCase()
           if (window.localStorage !== undefined) {
-            window.localStorage.setItem('itiAutoCountry', this.autoCountry);
+            window.localStorage.setItem('itiAutoCountry', this.autoCountry)
           }
           // tell all instances the auto country is ready
           // TODO: this should just be the current instances
@@ -558,40 +556,40 @@ class IntlTelInput extends Component {
           // somewhere else).
           // Using setTimeout means that the current thread of execution will finish before
           // executing this, which allows the plugin to finish initialising.
-          this.autoCountryLoaded();
-        });
+          this.autoCountryLoaded()
+        })
       }
     }
-  };
+  }
 
   cap = number => {
-    const max = this.tel ? this.tel.getAttribute('maxlength') : number;
+    const max = this.tel ? this.tel.getAttribute('maxlength') : number
 
-    return max && number.length > max ? number.substr(0, max) : number;
-  };
+    return max && number.length > max ? number.substr(0, max) : number
+  }
 
   removeEmptyDialCode = () => {
-    const value = this.state.value;
-    const startsPlus = value.charAt(0) === '+';
+    const value = this.state.value
+    const startsPlus = value.charAt(0) === '+'
 
     if (startsPlus) {
-      const numeric = utils.getNumeric(value);
+      const numeric = utils.getNumeric(value)
 
       // if just a plus, or if just a dial code
       if (!numeric || this.selectedCountryData.dialCode === numeric) {
         this.setState({
           value: '',
-        });
+        })
       }
     }
-  };
+  }
 
   // highlight the next/prev item in the list (and ensure it is visible)
   handleUpDownKey = key => {
-    const current = this.flagDropDown.querySelectorAll('.highlight')[0];
-    const prevElement = current ? current.previousElementSibling : undefined;
-    const nextElement = current ? current.nextElementSibling : undefined;
-    let next = key === KEYS.UP ? prevElement : nextElement;
+    const current = this.flagDropDown.querySelectorAll('.highlight')[0]
+    const prevElement = current ? current.previousElementSibling : undefined
+    const nextElement = current ? current.nextElementSibling : undefined
+    let next = key === KEYS.UP ? prevElement : nextElement
 
     if (next) {
       // skip the divider
@@ -599,27 +597,27 @@ class IntlTelInput extends Component {
         next =
           key === KEYS.UP
             ? next.previousElementSibling
-            : next.nextElementSibling;
+            : next.nextElementSibling
       }
 
-      this.scrollTo(next);
+      this.scrollTo(next)
 
-      const selectedIndex = utils.retrieveLiIndex(next);
+      const selectedIndex = utils.retrieveLiIndex(next)
 
       this.setState({
         showDropdown: true,
         highlightedCountry: selectedIndex,
-      });
+      })
     }
-  };
+  }
 
   // select the currently highlighted item
   handleEnterKey = () => {
-    const current = this.flagDropDown.querySelectorAll('.highlight')[0];
+    const current = this.flagDropDown.querySelectorAll('.highlight')[0]
 
     if (current) {
-      const selectedIndex = utils.retrieveLiIndex(current);
-      const countryCode = current.getAttribute('data-country-code');
+      const selectedIndex = utils.retrieveLiIndex(current)
+      const countryCode = current.getAttribute('data-country-code')
 
       this.setState(
         {
@@ -628,39 +626,37 @@ class IntlTelInput extends Component {
           countryCode,
         },
         () => {
-          this.setFlag(this.state.countryCode);
-          this.unbindDocumentClick();
+          this.setFlag(this.state.countryCode)
+          this.unbindDocumentClick()
         }
-      );
+      )
     }
-  };
+  }
 
   // find the first list item whose name starts with the query string
   searchForCountry = query => {
     for (let i = 0, max = this.countries.length; i < max; i++) {
       if (utils.startsWith(this.countries[i].name, query)) {
         const listItem = this.flagDropDown.querySelector(
-          `.country-list [data-country-code="${
-            this.countries[i].iso2
-          }"]:not(.preferred)`
-        );
+          `.country-list [data-country-code="${this.countries[i].iso2}"]:not(.preferred)`
+        )
 
-        const selectedIndex = utils.retrieveLiIndex(listItem);
+        const selectedIndex = utils.retrieveLiIndex(listItem)
 
         // update highlighting and scroll
         this.setState({
           showDropdown: true,
           highlightedCountry: selectedIndex,
-        });
-        this.scrollTo(listItem, true);
-        break;
+        })
+        this.scrollTo(listItem, true)
+        break
       }
     }
-  };
+  }
 
   formatNumber = number => {
     if (window.intlTelInputUtils && this.selectedCountryData) {
-      let format = window.intlTelInputUtils.numberFormat.INTERNATIONAL;
+      let format = window.intlTelInputUtils.numberFormat.INTERNATIONAL
 
       if (
         /* eslint-disable no-mixed-operators */
@@ -668,18 +664,18 @@ class IntlTelInput extends Component {
         number.charAt(0) !== '+'
         /* eslint-enable no-mixed-operators */
       ) {
-        format = window.intlTelInputUtils.numberFormat.NATIONAL;
+        format = window.intlTelInputUtils.numberFormat.NATIONAL
       }
 
       number = window.intlTelInputUtils.formatNumber(
         number,
         this.selectedCountryData.iso2,
         format
-      );
+      )
     }
 
-    return number;
-  };
+    return number
+  }
 
   // update the input's value to the given val (format first if possible)
   // if doNotify is true, calls notifyPhoneNumberChange with the formatted value
@@ -690,16 +686,16 @@ class IntlTelInput extends Component {
         !this.props.separateDialCode &&
         (this.nationalMode || number.charAt(0) !== '+')
           ? window.intlTelInputUtils.numberFormat.NATIONAL
-          : window.intlTelInputUtils.numberFormat.INTERNATIONAL;
+          : window.intlTelInputUtils.numberFormat.INTERNATIONAL
 
       number = window.intlTelInputUtils.formatNumber(
         number,
         this.selectedCountryData.iso2,
         format
-      );
+      )
     }
 
-    number = this.beforeSetNumber(number);
+    number = this.beforeSetNumber(number)
 
     this.setState(
       {
@@ -708,13 +704,13 @@ class IntlTelInput extends Component {
       },
       () => {
         if (doNotify) {
-          this.notifyPhoneNumberChange(number);
+          this.notifyPhoneNumberChange(number)
         }
 
-        this.unbindDocumentClick();
+        this.unbindDocumentClick()
       }
-    );
-  };
+    )
+  }
 
   // check if need to select a new flag based on the given number
   // Note: called from _setInitialState, keyup handler, setNumber
@@ -734,21 +730,21 @@ class IntlTelInput extends Component {
       number.charAt(0) !== '+'
     ) {
       if (number.charAt(0) !== '1') {
-        number = `1${number}`;
+        number = `1${number}`
       }
-      number = `+${number}`;
+      number = `+${number}`
     }
 
     // try and extract valid dial code from input
-    const dialCode = this.getDialCode(number);
-    let countryCode = null;
+    const dialCode = this.getDialCode(number)
+    let countryCode = null
 
     if (dialCode) {
       // check if one of the matching countries is already selected
-      const countryCodes = this.countryCodes[utils.getNumeric(dialCode)];
+      const countryCodes = this.countryCodes[utils.getNumeric(dialCode)]
       const alreadySelected =
         this.selectedCountryData &&
-        countryCodes.indexOf(this.selectedCountryData.iso2) !== -1;
+        countryCodes.indexOf(this.selectedCountryData.iso2) !== -1
 
       // if a matching country is not already selected
       // (or this is an unknown NANP area code): choose the first in the list
@@ -757,8 +753,8 @@ class IntlTelInput extends Component {
         // so we must find the first non-empty index
         for (let j = 0; j < countryCodes.length; j++) {
           if (countryCodes[j]) {
-            countryCode = countryCodes[j];
-            break;
+            countryCode = countryCodes[j]
+            break
           }
         }
       }
@@ -766,56 +762,56 @@ class IntlTelInput extends Component {
       // invalid dial code, so empty
       // Note: use getNumeric here because the number has not been
       // formatted yet, so could contain bad chars
-      countryCode = null;
+      countryCode = null
     }
 
     if (countryCode !== null) {
-      this.setFlag(countryCode, isInit);
+      this.setFlag(countryCode, isInit)
     }
-  };
+  }
 
   // filter the given countries using the process function
   filterCountries = (countryArray, processFunc) => {
-    let i;
+    let i
 
     // standardise case
     for (i = 0; i < countryArray.length; i++) {
-      countryArray[i] = countryArray[i].toLowerCase();
+      countryArray[i] = countryArray[i].toLowerCase()
     }
 
     // build instance country array
-    this.countries = [];
+    this.countries = []
     for (i = 0; i < AllCountries.getCountries().length; i++) {
       if (
         processFunc(countryArray.indexOf(AllCountries.getCountries()[i].iso2))
       ) {
-        this.countries.push(AllCountries.getCountries()[i]);
+        this.countries.push(AllCountries.getCountries()[i])
       }
     }
-  };
+  }
 
   // prepare all of the country data, including onlyCountries and preferredCountries options
   processCountryData = () => {
     // format countries data to what is necessary for component function
     // defaults to data defined in `AllCountries`
-    AllCountries.initialize(this.props.countriesData);
+    AllCountries.initialize(this.props.countriesData)
 
     // process onlyCountries or excludeCountries array if present
-    this.processAllCountries.call(this);
+    this.processAllCountries.call(this)
 
     // process the countryCodes map
-    this.processCountryCodes.call(this);
+    this.processCountryCodes.call(this)
 
     // set the preferredCountries property
-    this.processPreferredCountries.call(this);
-  };
+    this.processPreferredCountries.call(this)
+  }
 
   handleOnBlur = e => {
-    this.removeEmptyDialCode();
+    this.removeEmptyDialCode()
     if (typeof this.props.onPhoneNumberBlur === 'function') {
-      const value = this.state.value;
-      const fullNumber = this.formatFullNumber(value);
-      const isValid = this.isValidNumber(fullNumber);
+      const value = this.state.value
+      const fullNumber = this.formatFullNumber(value)
+      const isValid = this.isValidNumber(fullNumber)
 
       this.props.onPhoneNumberBlur(
         isValid,
@@ -824,15 +820,15 @@ class IntlTelInput extends Component {
         fullNumber,
         this.getExtension(value),
         e
-      );
+      )
     }
-  };
+  }
 
   handleOnFocus = e => {
     if (typeof this.props.onPhoneNumberFocus === 'function') {
-      const value = this.state.value;
-      const fullNumber = this.formatFullNumber(value);
-      const isValid = this.isValidNumber(fullNumber);
+      const value = this.state.value
+      const fullNumber = this.formatFullNumber(value)
+      const isValid = this.isValidNumber(fullNumber)
 
       this.props.onPhoneNumberFocus(
         isValid,
@@ -841,26 +837,26 @@ class IntlTelInput extends Component {
         fullNumber,
         this.getExtension(value),
         e
-      );
+      )
     }
-  };
+  }
 
   bindDocumentClick = () => {
-    this.isOpening = true;
+    this.isOpening = true
     document
       .querySelector('html')
-      .addEventListener('click', this.handleDocumentClick);
-  };
+      .addEventListener('click', this.handleDocumentClick)
+  }
 
   unbindDocumentClick = () => {
     document
       .querySelector('html')
-      .removeEventListener('click', this.handleDocumentClick);
-  };
+      .removeEventListener('click', this.handleDocumentClick)
+  }
 
   clickSelectedFlag = e => {
-    const { allowDropdown, onFlagClick } = this.props;
-    const { showDropdown, disabled, readonly } = this.state;
+    const { allowDropdown, onFlagClick } = this.props
+    const { showDropdown, disabled, readonly } = this.state
 
     if (!showDropdown && !disabled && !readonly && allowDropdown) {
       this.setState(
@@ -870,22 +866,22 @@ class IntlTelInput extends Component {
           outerHeight: utils.getOuterHeight(this.tel),
         },
         () => {
-          const highlightItem = this.flagDropDown.querySelector('.highlight');
+          const highlightItem = this.flagDropDown.querySelector('.highlight')
 
           if (highlightItem) {
-            this.scrollTo(highlightItem, true);
+            this.scrollTo(highlightItem, true)
           }
         }
-      );
+      )
     } else if (showDropdown) {
       // need to hide dropdown when click on opened flag button
-      this.toggleDropdown(false);
+      this.toggleDropdown(false)
     }
     // Allow main app to do things when flag icon is clicked
     if (typeof onFlagClick === 'function') {
-      onFlagClick(e);
+      onFlagClick(e)
     }
-  };
+  }
 
   // update the input placeholder to an
   // example number from the currently selected country
@@ -895,29 +891,29 @@ class IntlTelInput extends Component {
       props.autoPlaceholder &&
       this.selectedCountryData
     ) {
-      const numberType = window.intlTelInputUtils.numberType[props.numberType];
+      const numberType = window.intlTelInputUtils.numberType[props.numberType]
       let placeholder = this.selectedCountryData.iso2
         ? window.intlTelInputUtils.getExampleNumber(
-          this.selectedCountryData.iso2,
-          this.nationalMode,
-          numberType
-        )
-        : '';
+            this.selectedCountryData.iso2,
+            this.nationalMode,
+            numberType
+          )
+        : ''
 
-      placeholder = this.beforeSetNumber(placeholder, props);
+      placeholder = this.beforeSetNumber(placeholder, props)
 
       if (typeof props.customPlaceholder === 'function') {
         placeholder = props.customPlaceholder(
           placeholder,
           this.selectedCountryData
-        );
+        )
       }
 
       this.setState({
         placeholder,
-      });
+      })
     }
-  };
+  }
 
   toggleDropdown = status => {
     this.setState(
@@ -926,102 +922,102 @@ class IntlTelInput extends Component {
       },
       () => {
         if (!this.state.showDropdown) {
-          this.unbindDocumentClick();
+          this.unbindDocumentClick()
         }
       }
-    );
-  };
+    )
+  }
 
   // check if an element is visible within it's container, else scroll until it is
   scrollTo = (element, middle) => {
     try {
-      const container = this.flagDropDown.querySelector('.country-list');
+      const container = this.flagDropDown.querySelector('.country-list')
       const containerHeight = parseFloat(
         window.getComputedStyle(container).getPropertyValue('height')
-      );
-      const containerTop = utils.offset(container).top;
-      const containerBottom = containerTop + containerHeight;
-      const elementHeight = utils.getOuterHeight(element);
-      const elementTop = utils.offset(element).top;
-      const elementBottom = elementTop + elementHeight;
-      const middleOffset = containerHeight / 2 - elementHeight / 2;
-      let newScrollTop = elementTop - containerTop + container.scrollTop;
+      )
+      const containerTop = utils.offset(container).top
+      const containerBottom = containerTop + containerHeight
+      const elementHeight = utils.getOuterHeight(element)
+      const elementTop = utils.offset(element).top
+      const elementBottom = elementTop + elementHeight
+      const middleOffset = containerHeight / 2 - elementHeight / 2
+      let newScrollTop = elementTop - containerTop + container.scrollTop
 
       if (elementTop < containerTop) {
         // scroll up
         if (middle) {
-          newScrollTop -= middleOffset;
+          newScrollTop -= middleOffset
         }
 
-        container.scrollTop = newScrollTop;
+        container.scrollTop = newScrollTop
       } else if (elementBottom > containerBottom) {
         // scroll down
         if (middle) {
-          newScrollTop += middleOffset;
+          newScrollTop += middleOffset
         }
 
-        const heightDifference = containerHeight - elementHeight;
+        const heightDifference = containerHeight - elementHeight
 
-        container.scrollTop = newScrollTop - heightDifference;
+        container.scrollTop = newScrollTop - heightDifference
       }
     } catch (err) {
       // do nothing
     }
-  };
+  }
 
   // replace any existing dial code with the new one
   // Note: called from _setFlag
   updateDialCode = (newDialCode, hasSelectedListItem) => {
-    const currentNumber = this.state.value;
+    const currentNumber = this.state.value
 
     if (!newDialCode) {
-      return currentNumber;
+      return currentNumber
     }
-    let newNumber = currentNumber;
+    let newNumber = currentNumber
 
     // save having to pass this every time
-    newDialCode = `+${newDialCode}`;
+    newDialCode = `+${newDialCode}`
 
     if (currentNumber.charAt(0) === '+') {
       // there's a plus so we're dealing with a replacement (doesn't matter if nationalMode or not)
-      const prevDialCode = this.getDialCode(currentNumber);
+      const prevDialCode = this.getDialCode(currentNumber)
 
       if (prevDialCode) {
         // current number contains a valid dial code, so replace it
-        newNumber = currentNumber.replace(prevDialCode, newDialCode);
+        newNumber = currentNumber.replace(prevDialCode, newDialCode)
       } else {
         // current number contains an invalid dial code, so ditch it
         // (no way to determine where the invalid dial code ends and the rest of the number begins)
-        newNumber = newDialCode;
+        newNumber = newDialCode
       }
     } else if (this.nationalMode || this.props.separateDialCode) {
       // don't do anything
     } else if (currentNumber) {
       // nationalMode is disabled
       // there is an existing value with no dial code: prefix the new dial code
-      newNumber = newDialCode + currentNumber;
+      newNumber = newDialCode + currentNumber
     } else if (hasSelectedListItem || !this.autoHideDialCode) {
       // no existing value and either they've just selected a list item, or autoHideDialCode is disabled: insert new dial code
-      newNumber = newDialCode;
+      newNumber = newDialCode
     }
 
     if (newNumber !== currentNumber) {
-      this.notifyPhoneNumberChange(newNumber);
+      this.notifyPhoneNumberChange(newNumber)
     }
 
-    return newNumber;
-  };
+    return newNumber
+  }
 
   generateMarkup = () => {
-    this.wrapperClass['separate-dial-code'] = this.props.separateDialCode;
+    this.wrapperClass['separate-dial-code'] = this.props.separateDialCode
 
     if (this.isMobile && this.props.useMobileFullscreenDropdown) {
-      document.querySelector('body').classList.add('iti-mobile');
+      document.querySelector('body').classList.add('iti-mobile')
       // on mobile, we want a full screen dropdown, so we must append it to the body
-      this.dropdownContainer = 'body';
-      window.addEventListener('scroll', this.handleWindowScroll);
+      this.dropdownContainer = 'body'
+      window.addEventListener('scroll', this.handleWindowScroll)
     }
-  };
+  }
 
   handleSelectedFlagKeydown = e => {
     if (
@@ -1032,48 +1028,48 @@ class IntlTelInput extends Component {
         e.which === KEYS.ENTER)
     ) {
       // prevent form from being submitted if "ENTER" was pressed
-      e.preventDefault();
+      e.preventDefault()
 
       // prevent event from being handled again by document
-      e.stopPropagation();
+      e.stopPropagation()
 
-      this.toggleDropdown(true);
+      this.toggleDropdown(true)
     }
 
     // allow navigation from dropdown to input on TAB
     if (e.which === KEYS.TAB) {
-      this.toggleDropdown(false);
+      this.toggleDropdown(false)
     }
-  };
+  }
 
   // validate the input val - assumes the global function isValidNumber (from libphonenumber)
   isValidNumber = number => {
-    const val = utils.trim(number);
+    const val = utils.trim(number)
     const countryCode =
       this.nationalMode || this.props.separateDialCode
         ? this.selectedCountryData.iso2
-        : '';
+        : ''
 
     if (window.intlTelInputUtils) {
-      return window.intlTelInputUtils.isValidNumber(val, countryCode);
+      return window.intlTelInputUtils.isValidNumber(val, countryCode)
     }
 
-    return false;
-  };
+    return false
+  }
 
   formatFullNumber = number => {
     return window.intlTelInputUtils
       ? this.getNumber(
-        number,
-        window.intlTelInputUtils.numberFormat.INTERNATIONAL
-      )
-      : number;
-  };
+          number,
+          window.intlTelInputUtils.numberFormat.INTERNATIONAL
+        )
+      : number
+  }
 
   notifyPhoneNumberChange = newNumber => {
     if (typeof this.props.onPhoneNumberChange === 'function') {
-      const fullNumber = this.formatFullNumber(newNumber);
-      const isValid = this.isValidNumber(fullNumber);
+      const fullNumber = this.formatFullNumber(newNumber)
+      const isValid = this.isValidNumber(fullNumber)
 
       this.props.onPhoneNumberChange(
         isValid,
@@ -1081,14 +1077,14 @@ class IntlTelInput extends Component {
         this.selectedCountryData,
         fullNumber,
         this.getExtension(newNumber)
-      );
+      )
     }
-  };
+  }
 
   // remove the dial code if separateDialCode is enabled
   beforeSetNumber = (number, props = this.props) => {
     if (props.separateDialCode) {
-      let dialCode = this.getDialCode(number);
+      let dialCode = this.getDialCode(number)
 
       if (dialCode) {
         // US dialCode is "+1", which is what we want
@@ -1097,7 +1093,7 @@ class IntlTelInput extends Component {
         // AS dialCode is "+1 684", which is what we want
         // Solution: if the country has area codes, then revert to just the dial code
         if (this.selectedCountryData.areaCodes !== null) {
-          dialCode = `+${this.selectedCountryData.dialCode}`;
+          dialCode = `+${this.selectedCountryData.dialCode}`
         }
         // a lot of numbers will have a space separating the dial code
         // and the main number, and some NANP numbers will have a hyphen
@@ -1107,14 +1103,14 @@ class IntlTelInput extends Component {
         const start =
           number[dialCode.length] === ' ' || number[dialCode.length] === '-'
             ? dialCode.length + 1
-            : dialCode.length;
+            : dialCode.length
 
-        number = number.substr(start);
+        number = number.substr(start)
       }
     }
 
-    return this.cap(number);
-  };
+    return this.cap(number)
+  }
 
   handleWindowScroll = () => {
     this.setState(
@@ -1122,29 +1118,29 @@ class IntlTelInput extends Component {
         showDropdown: false,
       },
       () => {
-        window.removeEventListener('scroll', this.handleWindowScroll);
+        window.removeEventListener('scroll', this.handleWindowScroll)
       }
-    );
-  };
+    )
+  }
 
   handleDocumentKeyDown = e => {
-    let queryTimer;
+    let queryTimer
 
     // prevent down key from scrolling the whole page,
     // and enter key from submitting a form etc
-    e.preventDefault();
+    e.preventDefault()
 
     if (e.which === KEYS.UP || e.which === KEYS.DOWN) {
       // up and down to navigate
-      this.handleUpDownKey(e.which);
+      this.handleUpDownKey(e.which)
     } else if (e.which === KEYS.ENTER) {
       // enter to select
-      this.handleEnterKey();
+      this.handleEnterKey()
     } else if (e.which === KEYS.ESC) {
       // esc to close
       this.setState({
         showDropdown: false,
-      });
+      })
     } else if (
       (e.which >= KEYS.A && e.which <= KEYS.Z) ||
       e.which === KEYS.SPACE
@@ -1152,25 +1148,25 @@ class IntlTelInput extends Component {
       // upper case letters (note: keyup/keydown only return upper case letters)
       // jump to countries that start with the query string
       if (queryTimer) {
-        clearTimeout(queryTimer);
+        clearTimeout(queryTimer)
       }
 
       if (!this.query) {
-        this.query = '';
+        this.query = ''
       }
-      this.query += String.fromCharCode(e.which);
-      this.searchForCountry(this.query);
+      this.query += String.fromCharCode(e.which)
+      this.searchForCountry(this.query)
       // if the timer hits 1 second, reset the query
       queryTimer = setTimeout(() => {
-        this.query = '';
-      }, 1000);
+        this.query = ''
+      }, 1000)
     }
-  };
+  }
 
   handleDocumentClick = e => {
     // Click at the outside of country list
     // and outside of flag button
-    const targetClass = e.target.getAttribute('class');
+    const targetClass = e.target.getAttribute('class')
 
     if (
       targetClass === null ||
@@ -1180,40 +1176,40 @@ class IntlTelInput extends Component {
         targetClass.indexOf('iti-flag') === -1 &&
         targetClass.indexOf('iti-arrow') === -1)
     ) {
-      this.isOpening = false;
+      this.isOpening = false
     }
 
     if (!this.isOpening) {
-      this.toggleDropdown(false);
+      this.toggleDropdown(false)
     }
-    this.isOpening = false;
-  };
+    this.isOpening = false
+  }
 
   // Either notify phoneNumber changed if component is controlled
   // or udpate the state and notify change if component is uncontrolled
   handleInputChange = e => {
-    let cursorPosition = e.target.selectionStart;
+    let cursorPosition = e.target.selectionStart
     // previous value is pre formatted value
-    const previousValue = e.target.value;
+    const previousValue = e.target.value
     // prior value is existing state value/ before update
-    const priorValue = this.state.value;
+    const priorValue = this.state.value
     const previousStringBeforeCursor =
       previousValue === ''
         ? previousValue
-        : previousValue.substring(0, cursorPosition);
+        : previousValue.substring(0, cursorPosition)
 
     // Don't format if user is deleting chars
     const formattedValue =
       previousValue.length < priorValue.length
         ? previousValue
-        : this.formatNumber(e.target.value);
-    const value = this.props.format ? formattedValue : e.target.value;
+        : this.formatNumber(e.target.value)
+    const value = this.props.format ? formattedValue : e.target.value
 
     cursorPosition = utils.getCursorPositionAfterFormating(
       previousStringBeforeCursor,
       previousValue,
       value
-    );
+    )
 
     if (this.props.value !== undefined) {
       this.setState(
@@ -1221,10 +1217,10 @@ class IntlTelInput extends Component {
           cursorPosition,
         },
         () => {
-          this.updateFlagFromNumber(value);
-          this.notifyPhoneNumberChange(value);
+          this.updateFlagFromNumber(value)
+          this.notifyPhoneNumberChange(value)
         }
-      );
+      )
     } else {
       this.setState(
         {
@@ -1232,52 +1228,50 @@ class IntlTelInput extends Component {
           cursorPosition,
         },
         () => {
-          this.updateFlagFromNumber(value);
-          this.notifyPhoneNumberChange(value);
+          this.updateFlagFromNumber(value)
+          this.notifyPhoneNumberChange(value)
         }
-      );
+      )
     }
-  };
+  }
 
   changeHighlightCountry = (showDropdown, selectedIndex) => {
     this.setState({
       showDropdown,
       highlightedCountry: selectedIndex,
-    });
-  };
+    })
+  }
 
   loadUtils = () => {
     if (window.intlTelInputUtils) {
-      this.utilsScriptDeferred.resolve();
+      this.utilsScriptDeferred.resolve()
     }
-  };
+  }
 
   // this is called when the geoip call returns
   autoCountryLoaded = () => {
     if (this.tempCountry === 'auto') {
-      this.tempCountry = this.autoCountry;
-      this.autoCountryDeferred.resolve();
+      this.tempCountry = this.autoCountry
+      this.autoCountryDeferred.resolve()
     }
-  };
+  }
 
   render() {
-    this.wrapperClass[this.props.containerClassName] = true;
-    const inputClass = this.props.inputClassName;
-    const wrapperStyle = Object.assign({}, this.props.style || {});
+    this.wrapperClass[this.props.containerClassName] = true
+    const inputClass = this.props.inputClassName
+    const wrapperStyle = Object.assign({}, this.props.style || {})
 
-    this.wrapperClass['allow-dropdown'] = this.allowDropdown;
-    this.wrapperClass.expanded = this.state.showDropdown;
+    this.wrapperClass['allow-dropdown'] = this.allowDropdown
+    this.wrapperClass.expanded = this.state.showDropdown
 
-    const wrapperClass = classNames(this.wrapperClass);
+    const wrapperClass = classNames(this.wrapperClass)
 
     const titleTip = this.selectedCountryData
-      ? `${this.selectedCountryData.name}: +${
-        this.selectedCountryData.dialCode
-      }`
-      : 'Unknown';
+      ? `${this.selectedCountryData.name}: +${this.selectedCountryData.dialCode}`
+      : 'Unknown'
 
     const value =
-      this.props.value !== undefined ? this.props.value : this.state.value;
+      this.props.value !== undefined ? this.props.value : this.state.value
 
     return (
       <div className={wrapperClass} style={wrapperStyle}>
@@ -1323,7 +1317,7 @@ class IntlTelInput extends Component {
           cursorPosition={this.state.cursorPosition}
         />
       </div>
-    );
+    )
   }
 }
 
@@ -1404,7 +1398,7 @@ IntlTelInput.propTypes = {
   format: PropTypes.bool,
   /** Allow main app to do things when flag icon is clicked. */
   onFlagClick: PropTypes.func,
-};
+}
 
 IntlTelInput.defaultProps = {
   containerClassName: 'intl-tel-input',
@@ -1457,6 +1451,6 @@ IntlTelInput.defaultProps = {
   // always format the number
   format: false,
   onFlagClick: null,
-};
+}
 
-export default IntlTelInput;
+export default IntlTelInput

--- a/src/components/RootModal.js
+++ b/src/components/RootModal.js
@@ -1,31 +1,31 @@
-import React, { Component, Fragment } from 'react';
-import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import ReactDOM from 'react-dom'
 
 export default class RootModal extends Component {
   static propTypes = {
     children: PropTypes.node,
-  };
+  }
 
   constructor(props) {
-    super(props);
+    super(props)
 
-    this.modalTarget = document.createElement('div');
-    this.modalTarget.className = 'intl-tel-input iti-container';
+    this.modalTarget = document.createElement('div')
+    this.modalTarget.className = 'intl-tel-input iti-container'
   }
 
   componentDidMount() {
-    document.body.appendChild(this.modalTarget);
+    document.body.appendChild(this.modalTarget)
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.modalTarget);
+    document.body.removeChild(this.modalTarget)
   }
 
   render() {
     return ReactDOM.createPortal(
       <Fragment>{this.props.children}</Fragment>,
       this.modalTarget
-    );
+    )
   }
 }

--- a/src/components/TelInput.js
+++ b/src/components/TelInput.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 export default class TelInput extends Component {
   static propTypes = {
@@ -18,41 +18,41 @@ export default class TelInput extends Component {
     inputProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     refCallback: PropTypes.func.isRequired,
     cursorPosition: PropTypes.number,
-  };
+  }
 
   state = {
     hasFocus: false,
-  };
+  }
 
   componentDidUpdate() {
     if (this.state.hasFocus) {
       this.tel.setSelectionRange(
         this.props.cursorPosition,
         this.props.cursorPosition
-      );
+      )
     }
   }
 
   refHandler = element => {
-    this.tel = element;
-    this.props.refCallback(element);
-  };
+    this.tel = element
+    this.props.refCallback(element)
+  }
 
   handleBlur = e => {
-    this.setState({ hasFocus: false });
+    this.setState({ hasFocus: false })
 
     if (typeof this.props.handleOnBlur === 'function') {
-      this.props.handleOnBlur(e);
+      this.props.handleOnBlur(e)
     }
-  };
+  }
 
   handleFocus = e => {
-    this.setState({ hasFocus: true });
+    this.setState({ hasFocus: true })
 
     if (typeof this.props.handleOnFocus === 'function') {
-      this.props.handleOnFocus(e);
+      this.props.handleOnFocus(e)
     }
-  };
+  }
 
   render() {
     return (
@@ -73,6 +73,6 @@ export default class TelInput extends Component {
         onFocus={this.handleFocus}
         autoFocus={this.props.autoFocus}
       />
-    );
+    )
   }
 }

--- a/src/components/__tests__/FlagDropDown.test.js
+++ b/src/components/__tests__/FlagDropDown.test.js
@@ -1,106 +1,106 @@
 /* eslint-disable react/no-find-dom-node, no-eval */
-import React from 'react';
-import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-dom/test-utils';
-import { mount } from 'enzyme';
-import IntlTelInput from '../IntlTelInput';
-import FlagDropDown from '../FlagDropDown';
-import CountryList from '../CountryList';
-import TelInput from '../TelInput';
+import React from 'react'
+import ReactDOM from 'react-dom'
+import ReactTestUtils from 'react-dom/test-utils'
+import { mount } from 'enzyme'
+import IntlTelInput from '../IntlTelInput'
+import FlagDropDown from '../FlagDropDown'
+import CountryList from '../CountryList'
+import TelInput from '../TelInput'
 
 // eslint-disable-next-line func-names
 describe('FlagDropDown', function() {
   beforeEach(() => {
-    jest.resetModules();
+    jest.resetModules()
 
     this.params = {
       containerClassName: 'intl-tel-input',
       inputClassName: 'form-control phoneNumber',
       fieldName: 'telephone',
       defaultCountry: 'tw',
-    };
+    }
 
     this.makeSubject = () => {
-      return mount(<IntlTelInput {...this.params} />);
-    };
-  });
+      return mount(<IntlTelInput {...this.params} />)
+    }
+  })
 
   it('should be rendered', () => {
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
-    const countryListComponent = subject.find(CountryList);
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
+    const countryListComponent = subject.find(CountryList)
 
-    expect(flagComponent.length).toBeTruthy();
-    expect(countryListComponent.length).toBeTruthy();
-  });
+    expect(flagComponent.length).toBeTruthy()
+    expect(countryListComponent.length).toBeTruthy()
+  })
 
   it('should load country "jp" from localStorage', async () => {
-    window.localStorage.setItem('itiAutoCountry', 'jp');
+    window.localStorage.setItem('itiAutoCountry', 'jp')
     this.params = {
       ...this.params,
       defaultCountry: 'auto',
-    };
-    const subject = await this.makeSubject();
+    }
+    const subject = await this.makeSubject()
 
     subject.instance().utilsScriptDeferred.then(() => {
-      expect(subject.state().countryCode).toBe('jp');
-      window.localStorage.clear();
-    });
-  });
+      expect(subject.state().countryCode).toBe('jp')
+      window.localStorage.clear()
+    })
+  })
 
   it('should has .separate-dial-code class when with separateDialCode = true', () => {
     this.params = {
       ...this.params,
       separateDialCode: true,
-    };
-    const subject = this.makeSubject();
+    }
+    const subject = this.makeSubject()
 
-    expect(subject.find('.separate-dial-code').length).toBeTruthy();
-  });
+    expect(subject.find('.separate-dial-code').length).toBeTruthy()
+  })
 
   it('should has "tw" in class name', () => {
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
 
-    expect(flagComponent.find('.iti-flag.tw').first().length).toBeTruthy();
-  });
+    expect(flagComponent.find('.iti-flag.tw').first().length).toBeTruthy()
+  })
 
   it('should not has .hide class after clicking flag component', () => {
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
 
     expect(
       subject.find(CountryList).find('.country-list.hide').length
-    ).toBeTruthy();
+    ).toBeTruthy()
     flagComponent
       .find('.selected-flag')
       .last()
-      .simulate('click');
+      .simulate('click')
 
-    subject.update();
+    subject.update()
     expect(
       subject.find(CountryList).find('.country-list.hide').length
-    ).toBeFalsy();
-  });
+    ).toBeFalsy()
+  })
 
   it('Simulate change to Japan flag in dropdown before & after', () => {
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
 
-    expect(subject.state().showDropdown).toBeFalsy();
-    expect(flagComponent.find('.iti-flag.tw').length).toBeTruthy();
-    flagComponent.simulate('click');
-    const japanOption = flagComponent.find('[data-country-code="jp"]');
+    expect(subject.state().showDropdown).toBeFalsy()
+    expect(flagComponent.find('.iti-flag.tw').length).toBeTruthy()
+    flagComponent.simulate('click')
+    const japanOption = flagComponent.find('[data-country-code="jp"]')
 
-    japanOption.simulate('click');
-    expect(flagComponent.find('.iti-flag.jp').length).toBeTruthy();
-    expect(subject.state().showDropdown).toBeFalsy();
-  });
+    japanOption.simulate('click')
+    expect(flagComponent.find('.iti-flag.jp').length).toBeTruthy()
+    expect(subject.state().showDropdown).toBeFalsy()
+  })
 
   it('Set onlyCountries', () => {
-    this.params.onlyCountries = ['tw', 'us', 'kr'];
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
+    this.params.onlyCountries = ['tw', 'us', 'kr']
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
 
     const result = [
       {
@@ -124,35 +124,35 @@ describe('FlagDropDown', function() {
         priority: 0,
         areaCodes: null,
       },
-    ];
+    ]
 
-    expect(flagComponent.props().countries).toEqual(result);
-  });
+    expect(flagComponent.props().countries).toEqual(result)
+  })
 
   it('Set excludeCountries', () => {
-    this.params.excludeCountries = ['us', 'kr'];
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
+    this.params.excludeCountries = ['us', 'kr']
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
 
-    expect(flagComponent.props().countries.length).toBe(241);
-  });
+    expect(flagComponent.props().countries.length).toBe(241)
+  })
 
   it('Set defaultCountry as "auto"', async () => {
     const lookup = callback => {
-      callback('jp');
-    };
+      callback('jp')
+    }
 
     this.params = {
       ...this.params,
       defaultCountry: 'auto',
       geoIpLookup: lookup,
-    };
-    const subject = await this.makeSubject();
+    }
+    const subject = await this.makeSubject()
 
     subject.instance().utilsScriptDeferred.then(() => {
-      expect(subject.state().countryCode).toBe('jp');
-    });
-  });
+      expect(subject.state().countryCode).toBe('jp')
+    })
+  })
 
   describe('with original ReactTestUtils', () => {
     it('Mouse over on country', () => {
@@ -162,37 +162,37 @@ describe('FlagDropDown', function() {
           fieldName="telephone"
           defaultCountry="tw"
         />
-      );
+      )
 
       const flagComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'selected-flag'
-      );
+      )
 
       const dropDownComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'country-list'
-      );
+      )
 
-      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(flagComponent));
+      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(flagComponent))
       const options = ReactDOM.findDOMNode(dropDownComponent).querySelectorAll(
         '.country:not([class="preferred"])'
-      );
+      )
       const koreaOption = ReactDOM.findDOMNode(dropDownComponent).querySelector(
         '[data-country-code="kr"]'
-      );
+      )
 
-      let index = -1;
+      let index = -1
 
       for (let i = 0, max = options.length; i < max; ++i) {
         if (options[i] === koreaOption) {
-          index = i;
+          index = i
         }
       }
 
-      ReactTestUtils.Simulate.mouseOver(koreaOption);
-      expect(renderedComponent.state.highlightedCountry).toBe(index);
-    });
+      ReactTestUtils.Simulate.mouseOver(koreaOption)
+      expect(renderedComponent.state.highlightedCountry).toBe(index)
+    })
 
     it('Simulate change to flag in dropdown by up and down key', () => {
       const renderedComponent = ReactTestUtils.renderIntoDocument(
@@ -201,36 +201,36 @@ describe('FlagDropDown', function() {
           fieldName="telephone"
           defaultCountry="tw"
         />
-      );
+      )
 
       const flagComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'selected-flag'
-      );
+      )
 
       expect(
         ReactDOM.findDOMNode(flagComponent).querySelector('.iti-flag').className
-      ).toBe('iti-flag tw');
+      ).toBe('iti-flag tw')
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Enter',
         keyCode: 13,
         which: 13,
-      });
-      expect(renderedComponent.state.showDropdown).toBeTruthy();
+      })
+      expect(renderedComponent.state.showDropdown).toBeTruthy()
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Tab',
         keyCode: 9,
         which: 9,
-      });
-      expect(renderedComponent.state.showDropdown).toBeFalsy();
+      })
+      expect(renderedComponent.state.showDropdown).toBeFalsy()
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Enter',
         keyCode: 13,
         which: 13,
-      });
+      })
 
       const pressUpEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
@@ -239,10 +239,10 @@ describe('FlagDropDown', function() {
         keyCode: 38,
         key: 'Up',
         which: 38,
-      });
+      })
 
-      document.dispatchEvent(pressUpEvent);
-      expect(renderedComponent.state.highlightedCountry).toBe(212);
+      document.dispatchEvent(pressUpEvent)
+      expect(renderedComponent.state.highlightedCountry).toBe(212)
 
       const pressEnterEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
@@ -251,15 +251,15 @@ describe('FlagDropDown', function() {
         keyCode: 13,
         key: 'Enter',
         which: 13,
-      });
+      })
 
-      document.dispatchEvent(pressEnterEvent);
-      expect(renderedComponent.state.showDropdown).toBeFalsy();
+      document.dispatchEvent(pressEnterEvent)
+      expect(renderedComponent.state.showDropdown).toBeFalsy()
       expect(
         ReactDOM.findDOMNode(flagComponent).querySelector('.iti-flag')
           .className === 'iti-flag sy'
-      );
-    });
+      )
+    })
 
     it('Simulate close the dropdown menu by ESC key', () => {
       const renderedComponent = ReactTestUtils.renderIntoDocument(
@@ -268,19 +268,19 @@ describe('FlagDropDown', function() {
           fieldName="telephone"
           defaultCountry="tw"
         />
-      );
+      )
 
       const flagComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'selected-flag'
-      );
+      )
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Enter',
         keyCode: 13,
         which: 13,
-      });
-      expect(renderedComponent.state.showDropdown).toBeTruthy();
+      })
+      expect(renderedComponent.state.showDropdown).toBeTruthy()
 
       const pressEscEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
@@ -289,11 +289,11 @@ describe('FlagDropDown', function() {
         keyCode: 27,
         key: 'Esc',
         which: 27,
-      });
+      })
 
-      document.dispatchEvent(pressEscEvent);
-      expect(renderedComponent.state.showDropdown).toBeFalsy();
-    });
+      document.dispatchEvent(pressEscEvent)
+      expect(renderedComponent.state.showDropdown).toBeFalsy()
+    })
 
     it('Simulate close the dropdown menu by clicking on document', () => {
       const renderedComponent = ReactTestUtils.renderIntoDocument(
@@ -302,29 +302,29 @@ describe('FlagDropDown', function() {
           fieldName="telephone"
           defaultCountry="tw"
         />
-      );
+      )
 
       const flagComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'selected-flag'
-      );
+      )
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Enter',
         keyCode: 13,
         which: 13,
-      });
-      expect(renderedComponent.state.showDropdown).toBeTruthy();
+      })
+      expect(renderedComponent.state.showDropdown).toBeTruthy()
 
       const clickEvent = new window.MouseEvent('click', {
         view: window,
         bubbles: true,
         cancelable: true,
-      });
+      })
 
-      document.querySelector('html').dispatchEvent(clickEvent);
-      expect(renderedComponent.state.showDropdown).toBeFalsy();
-    });
+      document.querySelector('html').dispatchEvent(clickEvent)
+      expect(renderedComponent.state.showDropdown).toBeFalsy()
+    })
 
     it('componentWillUnmount', () => {
       const renderedComponent = ReactTestUtils.renderIntoDocument(
@@ -333,31 +333,31 @@ describe('FlagDropDown', function() {
           fieldName="telephone"
           defaultCountry="tw"
         />
-      );
+      )
 
       const flagComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'selected-flag'
-      );
+      )
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Enter',
         keyCode: 13,
         which: 13,
-      });
-      expect(renderedComponent.state.showDropdown).toBeTruthy();
+      })
+      expect(renderedComponent.state.showDropdown).toBeTruthy()
 
-      renderedComponent.componentWillUnmount();
+      renderedComponent.componentWillUnmount()
 
       const clickEvent = new window.MouseEvent('click', {
         view: window,
         bubbles: true,
         cancelable: true,
-      });
+      })
 
-      document.querySelector('html').dispatchEvent(clickEvent);
-      expect(renderedComponent.state.showDropdown).toBeTruthy();
-    });
+      document.querySelector('html').dispatchEvent(clickEvent)
+      expect(renderedComponent.state.showDropdown).toBeTruthy()
+    })
 
     it('Simulate search country name in dropdown menu', () => {
       const renderedComponent = ReactTestUtils.renderIntoDocument(
@@ -366,19 +366,19 @@ describe('FlagDropDown', function() {
           fieldName="telephone"
           defaultCountry="tw"
         />
-      );
+      )
 
       const flagComponent = ReactTestUtils.findRenderedDOMComponentWithClass(
         renderedComponent,
         'selected-flag'
-      );
+      )
 
       ReactTestUtils.Simulate.keyDown(ReactDOM.findDOMNode(flagComponent), {
         key: 'Enter',
         keyCode: 13,
         which: 13,
-      });
-      expect(renderedComponent.state.showDropdown).toBe(true);
+      })
+      expect(renderedComponent.state.showDropdown).toBe(true)
 
       const pressJEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
@@ -387,7 +387,7 @@ describe('FlagDropDown', function() {
         keyCode: 74,
         key: 'J',
         which: 74,
-      });
+      })
       const pressAEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
         cancelable: true,
@@ -395,7 +395,7 @@ describe('FlagDropDown', function() {
         keyCode: 65,
         key: 'A',
         which: 65,
-      });
+      })
       const pressPEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
         cancelable: true,
@@ -403,11 +403,11 @@ describe('FlagDropDown', function() {
         keyCode: 80,
         key: 'P',
         which: 80,
-      });
+      })
 
-      document.dispatchEvent(pressJEvent);
-      document.dispatchEvent(pressAEvent);
-      document.dispatchEvent(pressPEvent);
+      document.dispatchEvent(pressJEvent)
+      document.dispatchEvent(pressAEvent)
+      document.dispatchEvent(pressPEvent)
       const pressEnterEvent = new window.KeyboardEvent('keydown', {
         bubbles: true,
         cancelable: true,
@@ -415,55 +415,55 @@ describe('FlagDropDown', function() {
         keyCode: 13,
         key: 'Enter',
         which: 13,
-      });
+      })
 
-      document.dispatchEvent(pressEnterEvent);
+      document.dispatchEvent(pressEnterEvent)
 
-      expect(renderedComponent.state.showDropdown).toBeFalsy();
-      expect(renderedComponent.state.highlightedCountry).toBe(108);
-      expect(renderedComponent.state.countryCode).toBe('jp');
-    });
-  });
+      expect(renderedComponent.state.showDropdown).toBeFalsy()
+      expect(renderedComponent.state.highlightedCountry).toBe(108)
+      expect(renderedComponent.state.countryCode).toBe('jp')
+    })
+  })
 
   it('customPlaceholder', () => {
-    let expected = '';
+    let expected = ''
     const customPlaceholder = (placeholder, countryData) => {
-      expected = `${placeholder},${countryData.iso2}`;
-    };
+      expected = `${placeholder},${countryData.iso2}`
+    }
 
-    this.params.customPlaceholder = customPlaceholder;
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
-    const countryListComponent = subject.find(CountryList);
+    this.params.customPlaceholder = customPlaceholder
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
+    const countryListComponent = subject.find(CountryList)
 
-    expect(expected).toBe('0912 345 678,tw');
-    flagComponent.simulate('click');
-    const japanOption = countryListComponent.find('[data-country-code="jp"]');
+    expect(expected).toBe('0912 345 678,tw')
+    flagComponent.simulate('click')
+    const japanOption = countryListComponent.find('[data-country-code="jp"]')
 
-    japanOption.simulate('click');
-    expect(expected).toBe('090-1234-5678,jp');
-  });
+    japanOption.simulate('click')
+    expect(expected).toBe('090-1234-5678,jp')
+  })
 
   it('onSelectFlag', () => {
-    let expected = '';
+    let expected = ''
     const onSelectFlag = (currentNumber, countryData, fullNumber, isValid) => {
       expected = Object.assign(
         {},
         { currentNumber, fullNumber, isValid, ...countryData }
-      );
-    };
+      )
+    }
 
-    this.params.onSelectFlag = onSelectFlag;
-    const subject = this.makeSubject();
-    const flagComponent = subject.find(FlagDropDown);
-    const inputComponent = subject.find(TelInput);
-    const countryListComponent = subject.find(CountryList);
+    this.params.onSelectFlag = onSelectFlag
+    const subject = this.makeSubject()
+    const flagComponent = subject.find(FlagDropDown)
+    const inputComponent = subject.find(TelInput)
+    const countryListComponent = subject.find(CountryList)
 
-    inputComponent.simulate('change', { target: { value: '+8109012345678' } });
-    flagComponent.simulate('click');
-    const japanOption = countryListComponent.find('[data-country-code="jp"]');
+    inputComponent.simulate('change', { target: { value: '+8109012345678' } })
+    flagComponent.simulate('click')
+    const japanOption = countryListComponent.find('[data-country-code="jp"]')
 
-    japanOption.simulate('click');
+    japanOption.simulate('click')
 
     expect(expected).toEqual({
       currentNumber: '+8109012345678',
@@ -474,29 +474,29 @@ describe('FlagDropDown', function() {
       dialCode: '81',
       priority: 0,
       areaCodes: null,
-    });
-  });
+    })
+  })
 
   it('should output formatted number with formatNumber function', () => {
-    this.params.format = true;
-    this.params.nationalMode = true;
-    const subject = this.makeSubject();
+    this.params.format = true
+    this.params.nationalMode = true
+    const subject = this.makeSubject()
 
     expect(subject.instance().formatNumber('+886 912 345 678')).toBe(
       '0912 345 678'
-    );
-  });
+    )
+  })
 
   it('should highlight country from preferred list', async () => {
-    const { defaultCountry } = this.params;
+    const { defaultCountry } = this.params
 
     this.params = {
       ...this.params,
       preferredCountries: ['us', 'gb', defaultCountry],
-    };
-    const subject = await this.makeSubject();
+    }
+    const subject = await this.makeSubject()
 
-    expect(defaultCountry).toBeTruthy();
-    expect(subject.state().highlightedCountry).toBe(2);
-  });
-});
+    expect(defaultCountry).toBeTruthy()
+    expect(subject.state().highlightedCountry).toBe(2)
+  })
+})

--- a/src/components/__tests__/RootModal.test.js
+++ b/src/components/__tests__/RootModal.test.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import { mount } from 'enzyme';
-import RootModal from '../RootModal';
+import React from 'react'
+import { mount } from 'enzyme'
+import RootModal from '../RootModal'
 
 // eslint-disable-next-line func-names
 describe('RootModal', function() {
   beforeEach(() => {
-    jest.resetModules();
+    jest.resetModules()
 
     this.makeSubject = () => {
       return mount(
@@ -15,37 +15,37 @@ describe('RootModal', function() {
         {
           attachTo: document.body,
         }
-      );
-    };
-  });
+      )
+    }
+  })
 
   it('should has a div.root tag', () => {
-    const subject = this.makeSubject();
+    const subject = this.makeSubject()
 
-    expect(subject.find('div.root').length).toBeTruthy();
-  });
+    expect(subject.find('div.root').length).toBeTruthy()
+  })
 
   it('should has parent element which has specific className', () => {
-    const subject = this.makeSubject();
+    const subject = this.makeSubject()
 
-    expect(subject.instance().modalTarget.classList[0]).toBe('intl-tel-input');
-    expect(subject.instance().modalTarget.classList[1]).toBe('iti-container');
-  });
+    expect(subject.instance().modalTarget.classList[0]).toBe('intl-tel-input')
+    expect(subject.instance().modalTarget.classList[1]).toBe('iti-container')
+  })
 
   it('should has a modalTarget in body', () => {
-    const subject = this.makeSubject();
+    const subject = this.makeSubject()
 
     subject.setState({
       foo: 'foo',
-    });
-    expect(subject.instance().modalTarget.classList[0]).toBe('intl-tel-input');
-    expect(subject.instance().modalTarget.classList[1]).toBe('iti-container');
-  });
+    })
+    expect(subject.instance().modalTarget.classList[0]).toBe('intl-tel-input')
+    expect(subject.instance().modalTarget.classList[1]).toBe('iti-container')
+  })
 
   it('should not has a modalTarget in body', () => {
-    const subject = this.makeSubject();
+    const subject = this.makeSubject()
 
-    subject.unmount();
-    expect(document.body.querySelector('.iti-container')).toBeNull();
-  });
-});
+    subject.unmount()
+    expect(document.body.querySelector('.iti-container')).toBeNull()
+  })
+})

--- a/src/components/__tests__/TelInput.test.js
+++ b/src/components/__tests__/TelInput.test.js
@@ -1,16 +1,16 @@
 /* eslint-disable no-eval, no-restricted-properties */
-import React from 'react';
-import { mount } from 'enzyme';
-import IntlTelInput from '../IntlTelInput';
-import TelInput from '../TelInput';
-import FlagDropDown from '../FlagDropDown';
+import React from 'react'
+import { mount } from 'enzyme'
+import IntlTelInput from '../IntlTelInput'
+import TelInput from '../TelInput'
+import FlagDropDown from '../FlagDropDown'
 
 // eslint-disable-next-line func-names
 describe('TelInput', function() {
   beforeEach(() => {
-    jest.resetModules();
+    jest.resetModules()
 
-    document.body.innerHTML = '<div id="root"></div>';
+    document.body.innerHTML = '<div id="root"></div>'
 
     this.params = {
       containerClassName: 'intl-tel-input',
@@ -19,30 +19,30 @@ describe('TelInput', function() {
       fieldId: 'telephone-id',
       defaultCountry: 'tw',
       defaultValue: '0999 123 456',
-    };
+    }
     this.makeSubject = () => {
       return mount(<IntlTelInput {...this.params} />, {
         attachTo: document.querySelector('#root'),
-      });
-    };
-  });
+      })
+    }
+  })
 
   it('should set fieldName as "telephone"', () => {
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(inputComponent.props().fieldName).toBe('telephone');
-  });
+    expect(inputComponent.props().fieldName).toBe('telephone')
+  })
 
   it('should set fieldId as "telephone-id"', () => {
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(inputComponent.props().fieldId).toBe('telephone-id');
-  });
+    expect(inputComponent.props().fieldId).toBe('telephone-id')
+  })
 
   it('onPhoneNumberChange without libphonenumber', () => {
-    let expected = '';
+    let expected = ''
     const onPhoneNumberChange = (
       isValid,
       newNumber,
@@ -50,71 +50,67 @@ describe('TelInput', function() {
       fullNumber,
       ext
     ) => {
-      expected = `${isValid},${newNumber},${
-        countryData.iso2
-      },${fullNumber},${ext}`;
-    };
+      expected = `${isValid},${newNumber},${countryData.iso2},${fullNumber},${ext}`
+    }
 
-    window.intlTelInputUtils = undefined;
+    window.intlTelInputUtils = undefined
 
-    this.params.onPhoneNumberChange = onPhoneNumberChange;
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    this.params.onPhoneNumberChange = onPhoneNumberChange
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('change', { target: { value: '+886911222333' } });
-    expect(expected).toBe('false,+886911222333,tw,+886911222333,');
-  });
+    inputComponent.simulate('change', { target: { value: '+886911222333' } })
+    expect(expected).toBe('false,+886911222333,tw,+886911222333,')
+  })
 
   it('should set value as "0999 123 456"', async () => {
-    const subject = await this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    const subject = await this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(inputComponent.props().value).toBe('0999 123 456');
-  });
+    expect(inputComponent.props().value).toBe('0999 123 456')
+  })
 
   it('should set className', () => {
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(
-      inputComponent.find('.form-control.phoneNumber').length
-    ).toBeTruthy();
-  });
+    expect(inputComponent.find('.form-control.phoneNumber').length).toBeTruthy()
+  })
 
   it('should not focused on render', () => {
-    const initialSelectFlag = IntlTelInput.prototype.selectFlag;
+    const initialSelectFlag = IntlTelInput.prototype.selectFlag
 
-    let focused = false;
+    let focused = false
 
     IntlTelInput.prototype.selectFlag = function selectFlag(
       countryCode,
       setFocus = true
     ) {
-      focused = focused || setFocus;
-      initialSelectFlag.call(this, countryCode, setFocus);
-    };
+      focused = focused || setFocus
+      initialSelectFlag.call(this, countryCode, setFocus)
+    }
 
     this.params = {
       ...this.params,
       value: '+886901234567',
       preferredCountries: ['kr', 'jp', 'tw'],
-    };
-    this.makeSubject();
+    }
+    this.makeSubject()
 
-    IntlTelInput.prototype.selectFlag = initialSelectFlag;
-    expect(focused).toBeFalsy();
-  });
+    IntlTelInput.prototype.selectFlag = initialSelectFlag
+    expect(focused).toBeFalsy()
+  })
 
   it('should has "kr" in preferred countries state', () => {
     this.params = {
       ...this.params,
       defaultCountry: 'zz',
       preferredCountries: ['kr', 'jp', 'tw'],
-    };
-    const subject = this.makeSubject();
+    }
+    const subject = this.makeSubject()
 
-    expect(subject.state().countryCode).toBe('kr');
-  });
+    expect(subject.state().countryCode).toBe('kr')
+  })
 
   it('should set countryCode as "af" in state, when giving an invalid default country', () => {
     this.params = {
@@ -122,97 +118,97 @@ describe('TelInput', function() {
       preferredCountries: [],
       defaultValue: '',
       defaultCountry: 'zz',
-    };
-    const subject = this.makeSubject();
+    }
+    const subject = this.makeSubject()
 
-    expect(subject.state().countryCode).toBe('af');
-  });
+    expect(subject.state().countryCode).toBe('af')
+  })
 
   it('getNumber without libphonenumber', () => {
-    window.intlTelInputUtils = undefined;
+    window.intlTelInputUtils = undefined
 
     this.params = {
       ...this.params,
-    };
-    const subject = this.makeSubject();
+    }
+    const subject = this.makeSubject()
 
-    expect(subject.instance().getNumber(1)).toBe('');
-  });
+    expect(subject.instance().getNumber(1)).toBe('')
+  })
 
   it('setNumber', () => {
-    const subject = this.makeSubject();
+    const subject = this.makeSubject()
 
-    subject.instance().setNumber('+810258310015');
-    expect(subject.state().countryCode).toBe('jp');
-  });
+    subject.instance().setNumber('+810258310015')
+    expect(subject.state().countryCode).toBe('jp')
+  })
 
   it('handleKeyUp', () => {
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('focus');
-    inputComponent.simulate('keyDown', { keyCode: 35 });
+    inputComponent.simulate('focus')
+    inputComponent.simulate('keyDown', { keyCode: 35 })
     inputComponent.simulate('keyUp', {
       key: 'Backspace',
       keyCode: 8,
       which: 8,
-    });
+    })
     inputComponent.simulate('change', {
       target: { value: '0999 123 45' },
-    });
+    })
 
-    const changedInputComponent = subject.find(TelInput);
+    const changedInputComponent = subject.find(TelInput)
 
-    expect(changedInputComponent.props().value).toBe('0999 123 45');
-  });
+    expect(changedInputComponent.props().value).toBe('0999 123 45')
+  })
 
   it('ensurePlus', () => {
     this.params = {
       ...this.params,
       nationalMode: false,
       defaultValue: '+886999111222345',
-    };
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    }
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('focus');
-    inputComponent.simulate('keyDown', { keyCode: 35 });
+    inputComponent.simulate('focus')
+    inputComponent.simulate('keyDown', { keyCode: 35 })
     const bspaceKey = {
       key: 'Backspace',
       keyCode: 8,
       which: 8,
-    };
+    }
 
-    inputComponent.simulate('keyUp', bspaceKey);
-    inputComponent.simulate('keyUp', bspaceKey);
-    inputComponent.simulate('keyUp', bspaceKey);
+    inputComponent.simulate('keyUp', bspaceKey)
+    inputComponent.simulate('keyUp', bspaceKey)
+    inputComponent.simulate('keyUp', bspaceKey)
     inputComponent.simulate('change', {
       target: { value: '+886 999 111 222' },
-    });
-    expect(subject.state().value).toBe('+886 999 111 222');
-  });
+    })
+    expect(subject.state().value).toBe('+886 999 111 222')
+  })
 
   it('Disabled nationalMode and input phone number', () => {
-    this.params.nationalMode = false;
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    this.params.nationalMode = false
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('change', { target: { value: '+886901234567' } });
+    inputComponent.simulate('change', { target: { value: '+886901234567' } })
 
-    const changedInputComponent = subject.find(TelInput);
+    const changedInputComponent = subject.find(TelInput)
 
-    expect(changedInputComponent.props().value).toBe('+886901234567');
-  });
+    expect(changedInputComponent.props().value).toBe('+886901234567')
+  })
 
   it('utils loaded', () => {
-    this.makeSubject();
+    this.makeSubject()
 
-    expect(typeof window.intlTelInputUtils === 'object');
-    expect(typeof window.intlTelInputUtils.isValidNumber === 'function');
-  });
+    expect(typeof window.intlTelInputUtils === 'object')
+    expect(typeof window.intlTelInputUtils.isValidNumber === 'function')
+  })
 
   it('onPhoneNumberChange', () => {
-    let expected = '';
+    let expected = ''
     const onPhoneNumberChange = (
       isValid,
       newNumber,
@@ -220,31 +216,29 @@ describe('TelInput', function() {
       fullNumber,
       ext
     ) => {
-      expected = `${isValid},${newNumber},${
-        countryData.iso2
-      },${fullNumber},${ext}`;
-    };
+      expected = `${isValid},${newNumber},${countryData.iso2},${fullNumber},${ext}`
+    }
 
-    this.params.onPhoneNumberChange = onPhoneNumberChange;
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    this.params.onPhoneNumberChange = onPhoneNumberChange
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('change', { target: { value: '+886911222333' } });
-    expect(expected).toBe('true,+886911222333,tw,+886 911 222 333,null');
-  });
+    inputComponent.simulate('change', { target: { value: '+886911222333' } })
+    expect(expected).toBe('true,+886911222333,tw,+886 911 222 333,null')
+  })
 
   it('Blur and cleaning the empty dialcode', () => {
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('change', { target: { value: '+886' } });
-    subject.instance().handleOnBlur();
-    expect(subject.state().value).toBe('');
-  });
+    inputComponent.simulate('change', { target: { value: '+886' } })
+    subject.instance().handleOnBlur()
+    expect(subject.state().value).toBe('')
+  })
 
   const testOnPhoneNumberEvent = ({ property, eventType }) =>
     it(`${property}`, () => {
-      let expected = '';
+      let expected = ''
       const onPhoneNumberEvent = (
         isValid,
         newNumber,
@@ -253,28 +247,26 @@ describe('TelInput', function() {
         ext,
         event
       ) => {
-        const { type } = event;
+        const { type } = event
 
-        expected = `${isValid},${newNumber},${
-          countryData.iso2
-        },${fullNumber},${ext},${type}`;
-      };
+        expected = `${isValid},${newNumber},${countryData.iso2},${fullNumber},${ext},${type}`
+      }
 
-      this.params[property] = onPhoneNumberEvent;
-      const subject = this.makeSubject();
-      const inputComponent = subject.find(TelInput);
+      this.params[property] = onPhoneNumberEvent
+      const subject = this.makeSubject()
+      const inputComponent = subject.find(TelInput)
 
-      inputComponent.simulate('change', { target: { value: '+886911222333' } });
-      inputComponent.simulate(eventType);
+      inputComponent.simulate('change', { target: { value: '+886911222333' } })
+      inputComponent.simulate(eventType)
       expect(expected).toBe(
         `true,+886911222333,tw,+886 911 222 333,null,${eventType}`
-      );
-    });
+      )
+    })
 
-  [
+  ;[
     { property: 'onPhoneNumberBlur', eventType: 'blur' },
     { property: 'onPhoneNumberFocus', eventType: 'focus' },
-  ].forEach(testOnPhoneNumberEvent);
+  ].forEach(testOnPhoneNumberEvent)
 
   it('should has empty value with false nationalMode, false autoHideDialCode and false separateDialCode', () => {
     this.params = {
@@ -283,240 +275,240 @@ describe('TelInput', function() {
       nationalMode: false,
       autoHideDialCode: false,
       separateDialCode: false,
-    };
-    const subject = this.makeSubject();
+    }
+    const subject = this.makeSubject()
 
-    expect(subject.state().value).toBe('+886');
-  });
+    expect(subject.state().value).toBe('+886')
+  })
 
   it('updateFlagFromNumber', () => {
     this.params = {
       defaultCountry: 'us',
       nationalMode: true,
-    };
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    }
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('change', { target: { value: '9183319436' } });
-    expect(subject.state().countryCode).toBe('us');
+    inputComponent.simulate('change', { target: { value: '9183319436' } })
+    expect(subject.state().countryCode).toBe('us')
 
-    inputComponent.simulate('change', { target: { value: '+' } });
-    expect(subject.state().countryCode).toBe('us');
-  });
+    inputComponent.simulate('change', { target: { value: '+' } })
+    expect(subject.state().countryCode).toBe('us')
+  })
 
   it('isValidNumber', () => {
-    const subject = this.makeSubject();
+    const subject = this.makeSubject()
 
-    expect(subject.instance().isValidNumber('0910123456')).toBeTruthy();
-    expect(subject.instance().isValidNumber('091012345')).toBeFalsy();
-  });
+    expect(subject.instance().isValidNumber('0910123456')).toBeTruthy()
+    expect(subject.instance().isValidNumber('091012345')).toBeFalsy()
+  })
 
   it('getFullNumber', () => {
     this.params = {
       ...this.params,
       separateDialCode: true,
-    };
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    }
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    inputComponent.simulate('change', { target: { value: '910123456' } });
-    expect(subject.instance().getFullNumber(910123456)).toBe('+886910123456');
-  });
+    inputComponent.simulate('change', { target: { value: '910123456' } })
+    expect(subject.instance().getFullNumber(910123456)).toBe('+886910123456')
+  })
 
   it('should render custom placeholder', () => {
-    this.params.placeholder = 'foo';
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    this.params.placeholder = 'foo'
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(inputComponent.props().placeholder).toBe('foo');
-  });
+    expect(inputComponent.props().placeholder).toBe('foo')
+  })
 
   // FIXME: Enzyme not support :focus in current time
   xit('should focus input when autoFocus set to true', () => {
-    this.params.autoFocus = true;
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    this.params.autoFocus = true
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(inputComponent.is(':focus')).toBeTruthy();
-  });
+    expect(inputComponent.is(':focus')).toBeTruthy()
+  })
 
   it('should not focus input when autoFocus set to false', () => {
-    this.params.autoFocus = false;
-    const subject = this.makeSubject();
-    const inputComponent = subject.find(TelInput);
+    this.params.autoFocus = false
+    const subject = this.makeSubject()
+    const inputComponent = subject.find(TelInput)
 
-    expect(document.activeElement).not.toBe(inputComponent);
-  });
+    expect(document.activeElement).not.toBe(inputComponent)
+  })
 
   describe('when mobile useragent', () => {
-    let defaultUserAgent;
+    let defaultUserAgent
 
     beforeEach(() => {
-      defaultUserAgent = navigator.userAgent;
-      window.navigator.__defineGetter__('userAgent', () => 'iPhone');
-    });
+      defaultUserAgent = navigator.userAgent
+      window.navigator.__defineGetter__('userAgent', () => 'iPhone')
+    })
 
     afterEach(() => {
-      window.navigator.__defineGetter__('userAgent', () => defaultUserAgent);
-    });
+      window.navigator.__defineGetter__('userAgent', () => defaultUserAgent)
+    })
 
     it('sets FlagDropDown "dropdowncontainer" prop to "body"', () => {
-      const subject = this.makeSubject();
-      const flagDropdownComponent = subject.find(FlagDropDown);
+      const subject = this.makeSubject()
+      const flagDropdownComponent = subject.find(FlagDropDown)
 
-      expect(flagDropdownComponent.props().dropdownContainer).toBe('body');
-    });
+      expect(flagDropdownComponent.props().dropdownContainer).toBe('body')
+    })
 
     it('sets FlagDropDown "isMobile" prop to true', () => {
-      const subject = this.makeSubject();
-      const flagDropdownComponent = subject.find(FlagDropDown);
+      const subject = this.makeSubject()
+      const flagDropdownComponent = subject.find(FlagDropDown)
 
-      expect(flagDropdownComponent.props().isMobile).toBeTruthy();
-    });
+      expect(flagDropdownComponent.props().isMobile).toBeTruthy()
+    })
 
     it('sets "iti-mobile" class to "body"', () => {
-      expect(document.body.className).toBe('iti-mobile');
-    });
+      expect(document.body.className).toBe('iti-mobile')
+    })
 
     it(`does not set FlagDropDown "dropdowncontainer" to "body"
        when "useMobileFullscreenDropdown" set to false`, () => {
-      this.params.useMobileFullscreenDropdown = false;
-      const subject = this.makeSubject();
-      const flagDropdownComponent = subject.find(FlagDropDown);
+      this.params.useMobileFullscreenDropdown = false
+      const subject = this.makeSubject()
+      const flagDropdownComponent = subject.find(FlagDropDown)
 
-      expect(flagDropdownComponent.props().dropdownContainer).toBe('');
-    });
-  });
+      expect(flagDropdownComponent.props().dropdownContainer).toBe('')
+    })
+  })
 
   describe('controlled', () => {
     it('should set the value', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
-      expect(subject.state().value).toBe('0999 123 456');
-    });
+      expect(subject.state().value).toBe('0999 123 456')
+    })
 
     it('should not change input value if value is constrained by parent', () => {
-      this.params.value = '0999 123 456';
-      const subject = this.makeSubject();
-      const inputComponent = subject.find(TelInput);
+      this.params.value = '0999 123 456'
+      const subject = this.makeSubject()
+      const inputComponent = subject.find(TelInput)
 
-      inputComponent.simulate('change', { target: { value: '12345' } });
-      expect(subject.state().value).toBe('0999 123 456');
-    });
+      inputComponent.simulate('change', { target: { value: '12345' } })
+      expect(subject.state().value).toBe('0999 123 456')
+    })
 
     it('should change input value on value prop change', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
-      subject.setProps({ value: '+447598455159' });
-      subject.update();
+      subject.setProps({ value: '+447598455159' })
+      subject.update()
 
-      expect(subject.find(FlagDropDown).props().highlightedCountry).toBe(1);
+      expect(subject.find(FlagDropDown).props().highlightedCountry).toBe(1)
 
-      subject.setProps({ value: '+1(201) 555-0129' });
-      subject.update();
+      subject.setProps({ value: '+1(201) 555-0129' })
+      subject.update()
 
-      expect(subject.find(FlagDropDown).props().highlightedCountry).toBe(0);
-    });
+      expect(subject.find(FlagDropDown).props().highlightedCountry).toBe(0)
+    })
 
     it('should update country flag when value updates', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
-      subject.setProps({ value: 'foo bar' });
-      subject.update();
+      subject.setProps({ value: 'foo bar' })
+      subject.update()
 
-      expect(subject.find(TelInput).props().value).toBe('foo bar');
-    });
+      expect(subject.find(TelInput).props().value).toBe('foo bar')
+    })
 
     it('should be able to delete country code after input field has been populated with number', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
-      subject.setProps({ value: '+447598455159' });
+      subject.setProps({ value: '+447598455159' })
 
-      subject.setProps({ value: '+' });
+      subject.setProps({ value: '+' })
 
-      expect(subject.state().value).toBe('+');
-    });
+      expect(subject.state().value).toBe('+')
+    })
 
     it('should change input placeholder on placeholder prop change', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
-      subject.setProps({ placeholder: 'Phone number' });
-      subject.update();
+      subject.setProps({ placeholder: 'Phone number' })
+      subject.update()
 
-      expect(subject.find(TelInput).props().placeholder).toBe('Phone number');
+      expect(subject.find(TelInput).props().placeholder).toBe('Phone number')
 
-      subject.setProps({ placeholder: 'Your phone' });
-      subject.update();
+      subject.setProps({ placeholder: 'Your phone' })
+      subject.update()
 
-      expect(subject.find(TelInput).props().placeholder).toBe('Your phone');
-    });
+      expect(subject.find(TelInput).props().placeholder).toBe('Your phone')
+    })
 
     it('should change input placeholder on customPlaceholder prop change', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
-      subject.setProps({ customPlaceholder: () => 'Phone number' });
-      subject.update();
+      subject.setProps({ customPlaceholder: () => 'Phone number' })
+      subject.update()
 
-      expect(subject.find(TelInput).props().placeholder).toBe('Phone number');
+      expect(subject.find(TelInput).props().placeholder).toBe('Phone number')
 
-      subject.setProps({ customPlaceholder: () => 'Your phone' });
-      subject.update();
+      subject.setProps({ customPlaceholder: () => 'Your phone' })
+      subject.update()
 
-      expect(subject.find(TelInput).props().placeholder).toBe('Your phone');
-    });
+      expect(subject.find(TelInput).props().placeholder).toBe('Your phone')
+    })
 
     it('should set "expanded" class to wrapper only when flags are open', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
       const flagComponent = subject
         .find(FlagDropDown)
         .find('.selected-flag')
-        .last();
+        .last()
 
-      flagComponent.simulate('click');
-      expect(subject.instance().wrapperClass.expanded).toBe(true);
+      flagComponent.simulate('click')
+      expect(subject.instance().wrapperClass.expanded).toBe(true)
 
       const taiwanOption = subject
         .find(FlagDropDown)
-        .find('[data-country-code="tw"]');
+        .find('[data-country-code="tw"]')
 
-      taiwanOption.simulate('click');
-      expect(subject.instance().wrapperClass.expanded).toBe(false);
-    });
-  });
+      taiwanOption.simulate('click')
+      expect(subject.instance().wrapperClass.expanded).toBe(false)
+    })
+  })
 
   describe('uncontrolled', () => {
     it('should initialize state with defaultValue', () => {
-      this.params.defaultValue = '54321';
-      const subject = this.makeSubject();
-      const inputComponent = subject.find(TelInput);
+      this.params.defaultValue = '54321'
+      const subject = this.makeSubject()
+      const inputComponent = subject.find(TelInput)
 
-      expect(inputComponent.props().value).toBe('54321');
-      expect(subject.state().value).toBe('54321');
-    });
+      expect(inputComponent.props().value).toBe('54321')
+      expect(subject.state().value).toBe('54321')
+    })
 
     it('should change value', () => {
-      this.params.defaultValue = '';
-      const subject = this.makeSubject();
-      const inputComponent = subject.find(TelInput);
+      this.params.defaultValue = ''
+      const subject = this.makeSubject()
+      const inputComponent = subject.find(TelInput)
 
-      inputComponent.simulate('change', { target: { value: '12345' } });
+      inputComponent.simulate('change', { target: { value: '12345' } })
 
-      const changedInputComponent = subject.find(TelInput);
+      const changedInputComponent = subject.find(TelInput)
 
-      expect(changedInputComponent.props().value).toBe('12345');
-      expect(subject.state().value).toBe('12345');
-    });
+      expect(changedInputComponent.props().value).toBe('12345')
+      expect(subject.state().value).toBe('12345')
+    })
 
     it('should change props value', () => {
-      const subject = this.makeSubject();
+      const subject = this.makeSubject()
 
       subject.setState({
         value: '+886912345678',
-      });
+      })
 
-      const changedInputComponent = subject.find(TelInput);
+      const changedInputComponent = subject.find(TelInput)
 
-      expect(changedInputComponent.props().value).toBe('+886912345678');
-    });
-  });
-});
+      expect(changedInputComponent.props().value).toBe('+886912345678')
+    })
+  })
+})

--- a/src/components/__tests__/utils.test.js
+++ b/src/components/__tests__/utils.test.js
@@ -1,75 +1,75 @@
-import jsdom from 'jsdom';
-import AllCountries from '../AllCountries';
-import utils from '../utils';
+import jsdom from 'jsdom'
+import AllCountries from '../AllCountries'
+import utils from '../utils'
 
 describe('utils', () => {
   it('arraysEqual', () => {
-    let a = [1, 2, 3];
-    let b = a;
+    let a = [1, 2, 3]
+    let b = a
 
-    expect(utils.arraysEqual(a, b)).toBeTruthy();
+    expect(utils.arraysEqual(a, b)).toBeTruthy()
 
-    a = [1, 2, 3];
-    b = null;
-    expect(utils.arraysEqual(a, b)).toBeFalsy();
+    a = [1, 2, 3]
+    b = null
+    expect(utils.arraysEqual(a, b)).toBeFalsy()
 
-    a = [1, 2, 3];
-    b = [2, 1, 4, 5];
-    expect(utils.arraysEqual(a, b)).toBeFalsy();
+    a = [1, 2, 3]
+    b = [2, 1, 4, 5]
+    expect(utils.arraysEqual(a, b)).toBeFalsy()
 
-    a = ['1', '2', '3'];
-    b = ['3', '1', '2'];
-    expect(utils.arraysEqual(a, b)).toBeFalsy();
-  });
+    a = ['1', '2', '3']
+    b = ['3', '1', '2']
+    expect(utils.arraysEqual(a, b)).toBeFalsy()
+  })
 
   it('shallowEquals', () => {
-    let a = [1, 2, 3];
-    let b = a;
+    let a = [1, 2, 3]
+    let b = a
 
-    expect(utils.shallowEquals(a, b)).toBeTruthy();
+    expect(utils.shallowEquals(a, b)).toBeTruthy()
 
     a = {
       x: ['1', '2', '3'],
       y: 'abc',
-    };
+    }
     b = {
       x: ['1', '2', '3'],
       y: 'abc',
-    };
-    expect(utils.shallowEquals(a, b)).toBeTruthy();
+    }
+    expect(utils.shallowEquals(a, b)).toBeTruthy()
 
     a = {
       x: ['1', '2', '3'],
       y: ['1', '3', '4'],
-    };
+    }
     b = {
       x: ['1', '2', '3'],
       y: ['4', '2'],
-    };
-    expect(utils.shallowEquals(a, b)).toBeFalsy();
+    }
+    expect(utils.shallowEquals(a, b)).toBeFalsy()
 
     a = {
       a: 1,
       b: 2,
-    };
-    b = Object.create(a);
-    b.c = 3;
-    expect(utils.shallowEquals(a, b)).toBeFalsy();
-  });
+    }
+    b = Object.create(a)
+    b.c = 3
+    expect(utils.shallowEquals(a, b)).toBeFalsy()
+  })
 
   it('trim', () => {
-    expect(utils.trim(undefined)).toBe('');
+    expect(utils.trim(undefined)).toBe('')
 
-    const str = ' Hello World   ';
+    const str = ' Hello World   '
 
-    expect(utils.trim(str)).toBe('Hello World');
-  });
+    expect(utils.trim(str)).toBe('Hello World')
+  })
 
   it('isNumeric', () => {
-    const num = 1.2;
+    const num = 1.2
 
-    expect(utils.isNumeric(num)).toBeTruthy();
-  });
+    expect(utils.isNumeric(num)).toBeTruthy()
+  })
 
   it('retrieveLiIndex', () => {
     const DEFAULT_HTML = `<html><body>
@@ -77,36 +77,36 @@ describe('utils', () => {
         <li class="a">a</li>
         <li class="b">b</li>
       </ul>
-    </body></html>`;
-    const doc = jsdom.jsdom(DEFAULT_HTML);
-    const bListItem = doc.querySelector('.b');
+    </body></html>`
+    const doc = jsdom.jsdom(DEFAULT_HTML)
+    const bListItem = doc.querySelector('.b')
 
-    expect(utils.retrieveLiIndex(bListItem)).toBe(1);
+    expect(utils.retrieveLiIndex(bListItem)).toBe(1)
 
-    const otherListItem = doc.querySelector('.z');
+    const otherListItem = doc.querySelector('.z')
 
-    expect(utils.retrieveLiIndex(otherListItem)).toBe(-1);
-  });
+    expect(utils.retrieveLiIndex(otherListItem)).toBe(-1)
+  })
 
   it('getNumeric', () => {
-    const str = 'Hello 1000 World';
+    const str = 'Hello 1000 World'
 
-    expect(utils.getNumeric(str)).toBe('1000');
-  });
+    expect(utils.getNumeric(str)).toBe('1000')
+  })
 
   it('startsWith', () => {
-    const str = 'Hello World';
+    const str = 'Hello World'
 
-    expect(utils.startsWith(str, 'H')).toBeTruthy();
-  });
+    expect(utils.startsWith(str, 'H')).toBeTruthy()
+  })
 
   it('isWindow', () => {
-    expect(utils.isWindow(global.window)).toBeTruthy();
-  });
+    expect(utils.isWindow(global.window)).toBeTruthy()
+  })
 
   it('getWindow', () => {
-    expect(utils.getWindow(global.window)).toBe(global.window);
-  });
+    expect(utils.getWindow(global.window)).toBe(global.window)
+  })
 
   it('getCountryData', () => {
     const result = {
@@ -115,14 +115,14 @@ describe('utils', () => {
       dialCode: '886',
       priority: 0,
       areaCodes: null,
-    };
+    }
 
     expect(utils.getCountryData(AllCountries.getCountries(), 'tw')).toEqual(
       result
-    );
+    )
     expect(
       utils.getCountryData(AllCountries.getCountries(), 'zz', true, true)
-    ).toBeNull();
+    ).toBeNull()
     expect(
       utils.getCountryData(
         AllCountries.getCountries(),
@@ -131,30 +131,30 @@ describe('utils', () => {
         false,
         country => `${country}!!`
       )
-    ).toEqual({});
-  });
+    ).toEqual({})
+  })
 
   it('findIndex', () => {
-    let array = [];
-    let predicate = () => true;
+    let array = []
+    let predicate = () => true
 
-    expect(utils.findIndex(array, predicate)).toEqual(-1);
+    expect(utils.findIndex(array, predicate)).toEqual(-1)
 
-    array = [1, 2, 3];
-    predicate = item => item === 2;
+    array = [1, 2, 3]
+    predicate = item => item === 2
 
-    expect(utils.findIndex(array, predicate)).toEqual(1);
+    expect(utils.findIndex(array, predicate)).toEqual(1)
 
-    array = [1, 2, 3];
-    predicate = item => item === 4;
+    array = [1, 2, 3]
+    predicate = item => item === 4
 
-    expect(utils.findIndex(array, predicate)).toEqual(-1);
-  });
+    expect(utils.findIndex(array, predicate)).toEqual(-1)
+  })
 
   it('getCursorPositionAfterFormating', () => {
-    let previousStringBeforeCursor = '9123';
-    let previousString = '912345';
-    let nextString = '912345';
+    let previousStringBeforeCursor = '9123'
+    let previousString = '912345'
+    let nextString = '912345'
 
     expect(
       utils.getCursorPositionAfterFormating(
@@ -162,23 +162,11 @@ describe('utils', () => {
         previousString,
         nextString
       )
-    ).toEqual(4);
+    ).toEqual(4)
 
-    previousStringBeforeCursor = '0912 345';
-    previousString = '0912 345 678';
-    nextString = '91234678';
-
-    expect(
-      utils.getCursorPositionAfterFormating(
-        previousStringBeforeCursor,
-        previousString,
-        nextString
-      )
-    ).toEqual(5);
-
-    previousStringBeforeCursor = '91234';
-    previousString = '91234678';
-    nextString = '0912 345 678';
+    previousStringBeforeCursor = '0912 345'
+    previousString = '0912 345 678'
+    nextString = '91234678'
 
     expect(
       utils.getCursorPositionAfterFormating(
@@ -186,11 +174,11 @@ describe('utils', () => {
         previousString,
         nextString
       )
-    ).toEqual(7);
+    ).toEqual(5)
 
-    previousStringBeforeCursor = '(201) 5';
-    previousString = '(201) 55-01';
-    nextString = '201-5501';
+    previousStringBeforeCursor = '91234'
+    previousString = '91234678'
+    nextString = '0912 345 678'
 
     expect(
       utils.getCursorPositionAfterFormating(
@@ -198,6 +186,18 @@ describe('utils', () => {
         previousString,
         nextString
       )
-    ).toEqual(5);
-  });
-});
+    ).toEqual(7)
+
+    previousStringBeforeCursor = '(201) 5'
+    previousString = '(201) 55-01'
+    nextString = '201-5501'
+
+    expect(
+      utils.getCursorPositionAfterFormating(
+        previousStringBeforeCursor,
+        previousString,
+        nextString
+      )
+    ).toEqual(5)
+  })
+})

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -9,4 +9,4 @@ export const KEYS = {
   Z: 90,
   SPACE: 32,
   TAB: 9,
-};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,11 +18,18 @@
   optionalDependencies:
     chokidar "^2.1.8"
 
-"@babel/code-frame@7.0.0", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
+"@babel/code-frame@7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   dependencies:
     "@babel/highlight" "^7.0.0"
+
+"@babel/code-frame@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
 
 "@babel/core@7.1.0":
   version "7.1.0"
@@ -261,9 +268,10 @@
     "@babel/traverse" "^7.1.5"
     "@babel/types" "^7.2.0"
 
-"@babel/highlight@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+"@babel/highlight@^7.0.0", "@babel/highlight@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
+  integrity sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -1847,6 +1855,16 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/json-schema@^7.0.3":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
 "@types/node@*":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
@@ -1893,6 +1911,33 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@typescript-eslint/experimental-utils@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
+  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@^1.10.2":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
+  integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.13.0"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
+  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
@@ -2077,29 +2122,47 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
+  dependencies:
+    acorn "^3.0.4"
+
 acorn-jsx@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
+  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
 acorn-walk@^6.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
 
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
+
 acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.5.3, acorn@^5.6.2, acorn@^5.7.3:
+acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2, acorn@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
-acorn@^6.0.1, acorn@^6.0.2:
+acorn@^6.0.1:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.5.tgz#81730c0815f3f3b34d8efa95cb7430965f4d887a"
 
 acorn@^6.0.5:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
+
+acorn@^6.0.7:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
+  integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -2169,11 +2232,21 @@ ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
+ajv@^6.1.0, ajv@^6.5.5:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
   dependencies:
     fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.10.2, ajv@^6.9.1:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
+  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -2206,11 +2279,7 @@ ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-escapes@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-
-ansi-escapes@^3.2.0:
+ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
 
@@ -2232,10 +2301,12 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-regex@^5.0.0:
   version "5.0.0"
@@ -2249,6 +2320,7 @@ ansi-styles@^2.2.1:
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
@@ -2329,6 +2401,7 @@ are-we-there-yet@~1.1.2:
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -2508,6 +2581,7 @@ ast-types@0.11.7:
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -3472,6 +3546,7 @@ bail@^1.0.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@0.0.8:
   version "0.0.8"
@@ -3685,6 +3760,7 @@ boxen@^2.0.0:
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -3986,8 +4062,9 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
 callsites@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -4120,6 +4197,7 @@ chalk@2.4.1:
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -4144,6 +4222,7 @@ chalk@~0.4.0:
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 check-error@^1.0.2:
   version "1.0.2"
@@ -4248,10 +4327,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circular-json@^0.3.1:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -4297,6 +4372,7 @@ cli-cursor@^1.0.1, cli-cursor@^1.0.2:
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
 
@@ -4334,6 +4410,7 @@ cli-width@^1.0.1:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -4424,6 +4501,7 @@ collection-visit@^1.0.0:
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
@@ -4437,6 +4515,7 @@ color-convert@^2.0.1:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
@@ -4512,7 +4591,7 @@ commander@~2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-common-tags@^1.8.0:
+common-tags@^1.4.0, common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
 
@@ -4558,6 +4637,7 @@ compression@^1.5.2:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 concat-stream@^1.5.0:
   version "1.6.2"
@@ -4734,6 +4814,11 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
+
+core-js@^3.1.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -5293,6 +5378,7 @@ deep-extend@^0.6.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 default-gateway@^2.6.0:
   version "2.7.2"
@@ -5453,6 +5539,11 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
+dlv@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -5480,6 +5571,13 @@ doctrine@1.5.0:
 doctrine@^2.0.0, doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
@@ -5865,6 +5963,7 @@ escape-html@^1.0.3, escape-html@~1.0.3:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.6.1, escodegen@^1.9.1:
   version "1.11.0"
@@ -5893,9 +5992,10 @@ eslint-config-airbnb@~17.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-prettier@^3.0.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz#41afc8d3b852e757f06274ed6c44ca16f939a57d"
+eslint-config-prettier@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
+  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -5951,6 +6051,13 @@ eslint-plugin-jsx-a11y@^6.1.1:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-prettier@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
+  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react@^7.11.0:
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.3.tgz#b9ca4cd7cd3f5d927db418a1950366a12d4568fd"
@@ -5980,68 +6087,90 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+eslint-scope@^3.7.1:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
+  integrity sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^5.3.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.12.0.tgz#fab3b908f60c52671fb14e996a450b96c743c859"
+eslint@^5.0.0, eslint@^5.3.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
+  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.5.3"
+    ajv "^6.9.1"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
-    doctrine "^2.1.0"
-    eslint-scope "^4.0.0"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.0"
+    espree "^5.0.1"
     esquery "^1.0.1"
     esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
+    file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
     glob "^7.1.2"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.1.0"
-    js-yaml "^3.12.0"
+    inquirer "^6.2.2"
+    js-yaml "^3.13.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.5"
+    lodash "^4.17.11"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
-    table "^5.0.2"
+    table "^5.2.3"
     text-table "^0.2.0"
 
-espree@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.0.tgz#fc7f984b62b36a0f543b13fb9cd7b9f4a7f5b65c"
+espree@^3.5.2:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
   dependencies:
-    acorn "^6.0.2"
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
+espree@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
+  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+  dependencies:
+    acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
@@ -6056,26 +6185,39 @@ esprima@^3.1.3:
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+esquery@^1.0.0, esquery@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.1.0.tgz#c5c0b66f383e7656404f86b31334d72524eddb48"
+  integrity sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==
   dependencies:
     estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-esutils@^2.0.0, esutils@^2.0.2:
+esutils@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 etag@~1.8.1:
   version "1.8.1"
@@ -6312,7 +6454,16 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
-external-editor@^3.0.0, external-editor@^3.0.3:
+external-editor@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
+external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
   dependencies:
@@ -6359,6 +6510,17 @@ extsprintf@^1.2.0:
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.4"
@@ -6384,12 +6546,14 @@ fast-glob@^3.1.1:
     picomatch "^2.2.1"
 
 fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fastparse@^1.1.1:
   version "1.1.2"
@@ -6452,6 +6616,7 @@ figures@^1.3.5, figures@^1.7.0:
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -6462,12 +6627,12 @@ figures@^3.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-entry-cache@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
-    flat-cache "^1.2.1"
-    object-assign "^4.0.1"
+    flat-cache "^2.0.1"
 
 file-loader@1.1.11:
   version "1.1.11"
@@ -6655,14 +6820,19 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
-flat-cache@^1.2.1:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
   dependencies:
-    circular-json "^0.3.1"
-    graceful-fs "^4.1.2"
-    rimraf "~2.6.2"
-    write "^0.2.1"
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
+  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
 flow-parser@^0.*:
   version "0.92.1"
@@ -6819,6 +6989,7 @@ fs-write-stream-atomic@^1.0.8, fs-write-stream-atomic@~1.0.10:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
@@ -6859,6 +7030,7 @@ function.prototype.name@^1.1.0:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 fuse.js@^3.0.1, fuse.js@^3.3.0:
   version "3.4.1"
@@ -7077,7 +7249,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -7088,7 +7260,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -7131,9 +7303,14 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.9.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249"
+
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^9.18.0:
   version "9.18.0"
@@ -7238,11 +7415,11 @@ got@^8.3.1, got@^8.3.2:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
-graceful-fs@^4.1.3, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
+graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -7338,6 +7515,7 @@ has-flag@^1.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -7764,6 +7942,7 @@ ignore@^3.3.5:
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 ignore@^5.1.4:
   version "5.1.4"
@@ -7864,14 +8043,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -7917,6 +8089,7 @@ import-local@^2.0.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
 in-publish@^2.0.0:
   version "2.0.0"
@@ -7953,22 +8126,23 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
 inflight@^1.0.4, inflight@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+inherits@2, inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-inherits@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
@@ -8024,24 +8198,6 @@ inquirer@^0.11.0:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.0"
-    figures "^2.0.0"
-    lodash "^4.17.10"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.1.0"
-    string-width "^2.1.0"
-    strip-ansi "^5.0.0"
-    through "^2.3.6"
-
 inquirer@^6.2.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
@@ -8058,6 +8214,25 @@ inquirer@^6.2.0:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
+    through "^2.3.6"
+
+inquirer@^6.2.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
+  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.12"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 internal-ip@^3.0.1:
@@ -8281,6 +8456,7 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -8436,6 +8612,7 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-property@^1.0.0, is-property@^1.0.2:
   version "1.0.2"
@@ -8532,6 +8709,7 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -8965,17 +9143,17 @@ js-yaml@3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.12.0, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -9082,6 +9260,7 @@ json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-bet
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -9090,6 +9269,7 @@ json-schema@0.2.3:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -9268,6 +9448,7 @@ leven@^2.1.0:
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
@@ -9657,6 +9838,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.merge@^4.6.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
@@ -9693,6 +9879,11 @@ lodash.toarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash.union@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
@@ -9712,12 +9903,12 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@4.17.15, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.2.1:
+lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@>4.17.4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10:
+lodash@>4.17.4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -9748,6 +9939,14 @@ logalot@^2.0.0, logalot@^2.1.0:
   dependencies:
     figures "^1.3.5"
     squeak "^1.0.0"
+
+loglevel-colored-level-prefix@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz#6a40218fdc7ae15fc76c3d0f3e676c465388603e"
+  integrity sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=
+  dependencies:
+    chalk "^1.1.3"
+    loglevel "^1.4.1"
 
 loglevel@^1.4.1:
   version "1.6.1"
@@ -10114,6 +10313,7 @@ mime@^2.4.3:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -10149,6 +10349,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
 minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -10163,6 +10364,7 @@ minimist-options@^3.0.1:
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
@@ -10232,6 +10434,7 @@ mixin-object@^2.0.1:
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
@@ -10283,11 +10486,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@2.1.1, ms@^2.1.1:
+ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
-ms@^2.0.0:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -10310,6 +10513,7 @@ mute-stream@0.0.5:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 mute-stream@~0.0.4:
   version "0.0.8"
@@ -10344,6 +10548,7 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 nearley@^2.7.10:
   version "2.16.0"
@@ -10388,6 +10593,7 @@ nested-object-assign@^1.0.1, nested-object-assign@^1.0.3:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -11073,6 +11279,7 @@ on-headers@~1.0.1:
 once@^1.3.0, once@^1.3.1, once@^1.4.0, once@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
@@ -11083,6 +11290,7 @@ onetime@^1.0.0:
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
 
@@ -11122,7 +11330,7 @@ optimize-css-assets-webpack-plugin@^5.0.1:
     cssnano "^4.1.0"
     last-call-webpack-plugin "^3.0.0"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -11132,6 +11340,18 @@ optionator@^0.8.1, optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+optionator@^0.8.2:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
 
 optipng-bin@^5.0.0:
   version "5.1.0"
@@ -11423,8 +11643,9 @@ param-case@2.1.x:
     no-case "^2.2.0"
 
 parent-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
 
@@ -11555,6 +11776,7 @@ path-exists@^4.0.0:
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-is-inside@^1.0.1, path-is-inside@^1.0.2, path-is-inside@~1.0.2:
   version "1.0.2"
@@ -11714,10 +11936,6 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
-
-pluralize@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -12075,6 +12293,7 @@ postcss@^7.0.14:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
@@ -12088,9 +12307,36 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.14.2:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+prettier-eslint@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-9.0.1.tgz#fbf507cde7329141cd368c6aeb54a70715d02cf4"
+  integrity sha512-KZT65QTosSAqBBqmrC+RpXbsMRe7Os2YSR9cAfFbDlyPAopzA/S5bioiZ3rpziNQNSJaOxmtXSx07EQ+o2Dlug==
+  dependencies:
+    "@typescript-eslint/parser" "^1.10.2"
+    common-tags "^1.4.0"
+    core-js "^3.1.4"
+    dlv "^1.1.0"
+    eslint "^5.0.0"
+    indent-string "^4.0.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^1.7.0"
+    pretty-format "^23.0.1"
+    require-relative "^0.8.7"
+    typescript "^3.2.1"
+    vue-eslint-parser "^2.0.2"
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.14.2, prettier@^1.7.0:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-error@^2.1.1:
   version "2.1.1"
@@ -12099,7 +12345,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^23.6.0:
+pretty-format@^23.0.1, pretty-format@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
   dependencies:
@@ -12129,6 +12375,7 @@ process@~0.5.1:
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   version "1.0.1"
@@ -12265,6 +12512,7 @@ punycode@^1.2.4, punycode@^1.4.1:
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 q@^1.1.2, q@^1.5.1:
   version "1.5.1"
@@ -12940,6 +13188,7 @@ regexp.prototype.flags@^1.2.0:
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -13141,6 +13390,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+  integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -13170,6 +13424,7 @@ resolve-from@^3.0.0:
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-global@1.0.0, resolve-global@^1.0.0:
   version "1.0.0"
@@ -13221,6 +13476,7 @@ restore-cursor@^1.0.1:
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
@@ -13252,7 +13508,7 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   dependencies:
@@ -13300,8 +13556,9 @@ run-async@^0.1.0:
     once "^1.3.0"
 
 run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
+  integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
 
@@ -13327,8 +13584,9 @@ rxjs@^5.0.0-beta.11:
     symbol-observable "1.0.1"
 
 rxjs@^6.1.0:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
+  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
   dependencies:
     tslib "^1.9.0"
 
@@ -13360,6 +13618,7 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 samsam@1.1.2:
   version "1.1.2"
@@ -13526,14 +13785,19 @@ semver-truncate@^1.1.2:
   dependencies:
     semver "^5.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
-"semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.7.1:
+"semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.5.0, semver@^5.5.1, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 semver@6.3.0, semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
@@ -13670,6 +13934,7 @@ shallowequal@^1.1.0:
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
@@ -13683,6 +13948,7 @@ shebang-command@^2.0.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -13760,9 +14026,10 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-slice-ansi@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.0.0.tgz#5373bdb8559b45676e8541c66916cdd6251612e7"
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
   dependencies:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
@@ -14033,6 +14300,7 @@ split@^1.0.0:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 squeak@^1.0.0:
   version "1.3.0"
@@ -14268,6 +14536,7 @@ stringstream@~0.0.4:
 strip-ansi@4.0.0, strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
 
@@ -14277,11 +14546,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
-    ansi-regex "^4.0.0"
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"
@@ -14374,6 +14644,7 @@ supports-color@^3.1.2:
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
@@ -14442,14 +14713,15 @@ symbol.prototype.description@^1.0.0:
   dependencies:
     has-symbols "^1.0.0"
 
-table@^5.0.2:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.1.tgz#92030192f1b7b51b6eeab23ed416862e47b70837"
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
   dependencies:
-    ajv "^6.6.1"
-    lodash "^4.17.11"
-    slice-ansi "2.0.0"
-    string-width "^2.1.1"
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.1"
@@ -14630,6 +14902,7 @@ tinycolor2@^1.4.1:
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
 
@@ -14764,8 +15037,9 @@ tryer@^1.0.0:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
 
 tslib@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -14788,6 +15062,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
 
@@ -14825,6 +15100,11 @@ type-is@~1.6.16:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^3.2.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"
@@ -15021,6 +15301,7 @@ upper-case@^1.1.1:
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
 
@@ -15196,6 +15477,18 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vue-eslint-parser@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
+  integrity sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==
+  dependencies:
+    debug "^3.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    lodash "^4.17.4"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
@@ -15470,6 +15763,7 @@ which-pm-runs@^1.0.0:
 which@1, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
@@ -15499,6 +15793,11 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
+word-wrap@~1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -15506,6 +15805,7 @@ wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 worker-farm@^1.5.2:
   version "1.6.0"
@@ -15539,6 +15839,7 @@ wrap-ansi@^6.2.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^1.2.0:
   version "1.3.4"
@@ -15573,9 +15874,10 @@ write-file-atomic@^2.3.0, write-file-atomic@^2.4.3:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
 


### PR DESCRIPTION
This PR consolidates the ESLint  and Prettier flows so that we can just run `eslint --fix` to also fix Prettier errors. It'll also prevent disparities between the two rulesets that would otherwise conflict.

The large changeset is due to running `eslint --fix` across the board, which will now also apply `prettier` rules and fix them.