### PR TITLE
fix: custom class prop update should not be cumulative

### DIFF
--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1257,14 +1257,16 @@ class IntlTelInput extends Component {
   }
 
   render() {
-    this.wrapperClass[this.props.containerClassName] = true
     const inputClass = this.props.inputClassName
     const wrapperStyle = Object.assign({}, this.props.style || {})
 
     this.wrapperClass['allow-dropdown'] = this.allowDropdown
     this.wrapperClass.expanded = this.state.showDropdown
 
-    const wrapperClass = classNames(this.wrapperClass)
+    const wrapperClass = classNames(
+      this.wrapperClass,
+      this.props.containerClassName
+    )
 
     const titleTip = this.selectedCountryData
       ? `${this.selectedCountryData.name}: +${this.selectedCountryData.dialCode}`

--- a/src/components/__tests__/IntlTelInput.test.js
+++ b/src/components/__tests__/IntlTelInput.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import IntlTelInput from '../IntlTelInput'
+
+describe('Style customization', () => {
+  it('correctly applies user-supplied classes on outer container', () => {
+    const component = shallow(<IntlTelInput />)
+    const mockClass = 'mock-class-1'
+    component.setProps({ containerClassName: mockClass })
+    expect(component.props().className).toMatchInlineSnapshot(
+      `"allow-dropdown mock-class-1"`
+    )
+    const otherMockClass = 'mock-class-2'
+    component.setProps({ containerClassName: otherMockClass })
+    expect(component.props().className).toMatchInlineSnapshot(
+      `"allow-dropdown mock-class-2"`
+    )
+  })
+})


### PR DESCRIPTION
Custom class prop updates should not be cumulative.

## Description
The classes passed via `containerClassName` were previously appended to a component property (`wrapperClass`) which did not flush the custom classes on rerender if the `containerClassName` prop was changed. This led to scenarios where the custom class passed by a user would change, the prop would change, and the resulting applied class would be the sum of the previous prop values instead of having the new custom class replace the old.

This was addressed by not saving the `containerClassName` value to `wrapperClass` but instead keeping it in `render`. This ensures that if the prop changes, the resulting classname will be updated accordingly.

This addresses #344.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)