### PR TITLE
fix: avoid await async libphonenumber-js-utils import

### DIFF
--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -507,13 +507,10 @@ class IntlTelInput extends Component {
     }
   }
 
-  initRequests = () => {
-    import('libphonenumber-js-utils')
-      .then(() => {
-        this.loadUtils()
-        this.utilsScriptDeferred.resolve()
-      })
-      .catch(() => 'An error occurred while loading the component')
+  initRequests = async () => {
+    await import('libphonenumber-js-utils')
+    this.loadUtils()
+    this.utilsScriptDeferred.resolve()
 
     if (this.tempCountry === 'auto') {
       this.loadAutoCountry()


### PR DESCRIPTION
## Description

### :construction: WIP

This PR makes the async import of `libphonenumber-js-utils` (from `initRequests`) a blocking import, resolving the problem from #347 (and any RTL-related issue that has the async import not be ready in time for the test). The asynchronous import really seems to be causing trouble with test runners. Clients are probably safe because so many things are happening in the browser that the user can't see the delay between the async import start and resolution.

Since the component is inert until the validation logic is ready, which happens when the import is done, it might make sense to have this toggle a loading state of some kind.

**This is still an experiment**

**Todo**
- [ ] Evaluate impact on usability
- [ ] Implement loading state based on whether the import is ready or not.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
