### PR TITLE
feat: new callback prop (renderComponent) to customize rendering

### DIFF
--- a/src/components/FlagDropDown.d.ts
+++ b/src/components/FlagDropDown.d.ts
@@ -30,6 +30,7 @@ export interface FlagDropDownProps {
   ) => void
   titleTip?: string
   refCallback: (instance: HTMLDivElement | null) => void
+  flagContainerProps?: React.HTMLProps<HTMLDivElement>
 }
 
 export interface FlagDropDownState {}

--- a/src/components/FlagDropDown.js
+++ b/src/components/FlagDropDown.js
@@ -24,6 +24,7 @@ export default class FlagDropDown extends Component {
     changeHighlightCountry: PropTypes.func,
     titleTip: PropTypes.string,
     refCallback: PropTypes.func.isRequired,
+    flagContainerProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   }
 
   genSelectedDialCode = () => {
@@ -92,7 +93,11 @@ export default class FlagDropDown extends Component {
     } = this.props
 
     return (
-      <div ref={refCallback} className="flag-container">
+      <div
+        ref={refCallback}
+        className="flag-container"
+        {...this.props.flagContainerProps}
+      >
         <div
           className="selected-flag"
           tabIndex={allowDropdown ? '0' : ''}

--- a/src/components/IntlTelInput.d.ts
+++ b/src/components/IntlTelInput.d.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { CountryData } from '../types'
+import { FlagDropDownProps } from "./FlagDropDown";
 
 export interface IntlTelInputProps {
   /**
@@ -202,6 +203,11 @@ export interface IntlTelInputProps {
    * @default null
    */
   onFlagClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+  /**
+   * Allow the main app to customize how the component is being rendered
+   * @default null
+   */
+   renderComponent?: (wrapperProps: Record<string, any>, flagDropDownProps: FlagDropDownProps, inputProps: Record<string, any>) => React.ReactNode
 }
 
 export interface IntlTelInputState {

--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1281,28 +1281,60 @@ class IntlTelInput extends Component {
     const value =
       this.props.value !== undefined ? this.props.value : this.state.value
 
+    const wrapperProps = {
+      className: wrapperClass,
+      style: wrapperStyle,
+    }
+    const flagDropDownProps = {
+      refCallback: this.setFlagDropdownRef,
+      allowDropdown: this.allowDropdown,
+      dropdownContainer: this.dropdownContainer,
+      separateDialCode: this.props.separateDialCode,
+      dialCode: this.state.dialCode,
+      clickSelectedFlag: this.clickSelectedFlag,
+      setFlag: this.setFlag,
+      countryCode: this.state.countryCode,
+      isMobile: this.isMobile,
+      handleSelectedFlagKeydown: this.handleSelectedFlagKeydown,
+      changeHighlightCountry: this.changeHighlightCountry,
+      countries: this.countries,
+      showDropdown: this.state.showDropdown,
+      inputTop: this.state.offsetTop,
+      inputOuterHeight: this.state.outerHeight,
+      preferredCountries: this.preferredCountries,
+      highlightedCountry: this.state.highlightedCountry,
+      titleTip,
+    }
+    const inputProps = {
+      ref: this.setTelRef,
+      onChange: this.handleInputChange,
+      onBlur: this.handleOnBlur,
+      onFocus: this.handleOnFocus,
+      className: inputClass,
+      disabled: this.state.disabled,
+      readonly: this.state.readonly,
+      name: this.props.fieldName,
+      id: this.props.fieldId,
+      value,
+      placeholder:
+        this.props.placeholder !== undefined
+          ? this.props.placeholder
+          : this.state.placeholder,
+      autoFocus: this.props.autoFocus,
+      autoComplete: this.props.autoComplete,
+      inputProps: this.props.telInputProps,
+      cursorPosition: this.state.cursorPosition,
+    }
+    if (this.props.renderComponent) {
+      return this.props.renderComponent(
+        wrapperProps,
+        flagDropDownProps,
+        inputProps,
+      )
+    }
     return (
-      <div className={wrapperClass} style={wrapperStyle}>
-        <FlagDropDown
-          refCallback={this.setFlagDropdownRef}
-          allowDropdown={this.allowDropdown}
-          dropdownContainer={this.dropdownContainer}
-          separateDialCode={this.props.separateDialCode}
-          dialCode={this.state.dialCode}
-          clickSelectedFlag={this.clickSelectedFlag}
-          setFlag={this.setFlag}
-          countryCode={this.state.countryCode}
-          isMobile={this.isMobile}
-          handleSelectedFlagKeydown={this.handleSelectedFlagKeydown}
-          changeHighlightCountry={this.changeHighlightCountry}
-          countries={this.countries}
-          showDropdown={this.state.showDropdown}
-          inputTop={this.state.offsetTop}
-          inputOuterHeight={this.state.outerHeight}
-          preferredCountries={this.preferredCountries}
-          highlightedCountry={this.state.highlightedCountry}
-          titleTip={titleTip}
-        />
+      <div {...wrapperProps}>
+        <FlagDropDown {...flagDropDownProps} />
         <TelInput
           refCallback={this.setTelRef}
           handleInputChange={this.handleInputChange}
@@ -1406,6 +1438,7 @@ IntlTelInput.propTypes = {
   format: PropTypes.bool,
   /** Allow main app to do things when flag icon is clicked. */
   onFlagClick: PropTypes.func,
+  renderComponent: PropTypes.func,
 }
 
 IntlTelInput.defaultProps = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,12 @@ import IntlTelInput, {
   IntlTelInputProps,
   IntlTelInputState,
 } from './components/IntlTelInput'
+import FlagDropDown, {
+  FlagDropDownProps,
+  FlagDropDownState
+} from './components/FlagDropDown'
 
 export default IntlTelInput
 export { IntlTelInputProps, IntlTelInputState }
+export { FlagDropDown, FlagDropDownProps, FlagDropDownState }
 export { CountryData } from './types'

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 import IntlTelInput from './components/IntlTelInput'
+import FlagDropDown from './components/FlagDropDown'
 
+export { FlagDropDown }
 export default IntlTelInput


### PR DESCRIPTION
Adds a new renderProp to allow user to customize how to render the component. 


## Description
Adds a new prop to IntlTelInput:
```tsx
{
  renderComponent? : (wrapperProps, flagDropDownProps, inputProps) => React.ReactNode
}
```

Currently, the rendering of the component is fixed with a `<div>` around  `<FlagDropDown ...>` and `<input>`. If this callback is provided, instead of rendering the fixed default, will call the callback with the relevant props for user to customize their own rendering.

If callback not provided, will use the existing default rendering (`<div ...> <FlagDropDown ...> <input ... >`), so it does not affect any existing usages.

This allows users to customize using whatever Input component from any UI libraries (bootstrap, Material UI, etc.),. This enables this component to work smoothly with material UI (and other UI libraries) without messing around with the CSS to reproduce the UI's behaviour.

- Also exposed the FlagDropDown component so that it can be used in the rendering.
- Add new prop flagContainerProps to inner component FlagDropDown to allow user to customize the flag container's properties.

Will post CodeSandbox when I figure out how to link the module dependency to my fork...

Example usage (Material UI):
```jsx
import InputAdornment from "@mui/material/InputAdornment";
import TextField from "@mui/material/TextField";
import IntlTelInput, { FlagDropDown } from "react-intl-tel-input";

<IntlTelInput
	value={phoneNumber}
	fieldName="phone"
	fieldId="phone_id"
	formatOnInit={true}
	autoHideDialCode={false}
	renderComponent={(wrapperProps, flagDropDownProps, inputProps) => {
	  flagDropDownProps.flagContainerProps = { style: { position: "relative" } };
          inputProps.inputRef = inputProps.ref;
          inputProps.ref = undefined;
	  inputProps.InputProps = {
		startAdornment: (
		  <InputAdornment position="start">
			<div {...wrapperProps}>
			  <FlagDropDown {...flagDropDownProps} />
			</div>
		  </InputAdornment>
		),
	  };
	  return (
		<TextField
		  variant="filled"
		  margin="dense"
		  size="small"
		  fullWidth
		  {...inputProps}
		/>
	  );
	}}
	onPhoneNumberChange={(v, nn) => setPhoneNumber(nn)}
  />
  ```


Example usage (reactstrap (bootstrap React)):
```jsx
import { Input, InputGroup, InputGroupAddon, InputGroupText } from "reactstrap";
import IntlTelInput, { FlagDropDown } from "react-intl-tel-input";

<IntlTelInput
	value={phoneNumber}
	fieldName="phone"
	fieldId="phone_id"
	formatOnInit={true}
	autoHideDialCode={false}
        renderComponent={(wrapperProps, flagDropDownProps, inputProps) => {
          flagDropDownProps.flagContainerProps = { style: { position: "relative" } };
          inputProps.innerRef = inputProps.ref;
          inputProps.ref = undefined;
          return (
            <InputGroup>
              <InputGroupAddon addonType="prepend">
                <InputGroupText>
                  <div {...wrapperProps}>
                    <FlagDropDown {...flagDropDownProps} />
                  </div>
                </InputGroupText>
              </InputGroupAddon>
              <Input {...inputProps} />
            </InputGroup>
          );
        }}
	onPhoneNumberChange={(v, nn) => setPhoneNumber(nn)}
  />
  ```

## Screenshots:

Below are actual working implementation of above code:

Material UI:

![image](https://user-images.githubusercontent.com/659450/137446976-536cb95b-c9ae-4889-8e98-870ded283263.png)

Reactstrap (Bootstrap React):

![image](https://user-images.githubusercontent.com/659450/137683008-506336a8-619c-49e2-85a2-b298d92a37b4.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have used ESLint & Prettier to follow the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Closes #391
