### PR TITLE
Fix selected flag overlaps other components

### DIFF
--- a/src/components/IntlTelInput.js
+++ b/src/components/IntlTelInput.js
@@ -1283,26 +1283,6 @@ class IntlTelInput extends Component {
 
     return (
       <div className={wrapperClass} style={wrapperStyle}>
-        <FlagDropDown
-          refCallback={this.setFlagDropdownRef}
-          allowDropdown={this.allowDropdown}
-          dropdownContainer={this.dropdownContainer}
-          separateDialCode={this.props.separateDialCode}
-          dialCode={this.state.dialCode}
-          clickSelectedFlag={this.clickSelectedFlag}
-          setFlag={this.setFlag}
-          countryCode={this.state.countryCode}
-          isMobile={this.isMobile}
-          handleSelectedFlagKeydown={this.handleSelectedFlagKeydown}
-          changeHighlightCountry={this.changeHighlightCountry}
-          countries={this.countries}
-          showDropdown={this.state.showDropdown}
-          inputTop={this.state.offsetTop}
-          inputOuterHeight={this.state.outerHeight}
-          preferredCountries={this.preferredCountries}
-          highlightedCountry={this.state.highlightedCountry}
-          titleTip={titleTip}
-        />
         <TelInput
           refCallback={this.setTelRef}
           handleInputChange={this.handleInputChange}
@@ -1323,6 +1303,26 @@ class IntlTelInput extends Component {
           autoComplete={this.props.autoComplete}
           inputProps={this.props.telInputProps}
           cursorPosition={this.state.cursorPosition}
+        />
+        <FlagDropDown
+          refCallback={this.setFlagDropdownRef}
+          allowDropdown={this.allowDropdown}
+          dropdownContainer={this.dropdownContainer}
+          separateDialCode={this.props.separateDialCode}
+          dialCode={this.state.dialCode}
+          clickSelectedFlag={this.clickSelectedFlag}
+          setFlag={this.setFlag}
+          countryCode={this.state.countryCode}
+          isMobile={this.isMobile}
+          handleSelectedFlagKeydown={this.handleSelectedFlagKeydown}
+          changeHighlightCountry={this.changeHighlightCountry}
+          countries={this.countries}
+          showDropdown={this.state.showDropdown}
+          inputTop={this.state.offsetTop}
+          inputOuterHeight={this.state.outerHeight}
+          preferredCountries={this.preferredCountries}
+          highlightedCountry={this.state.highlightedCountry}
+          titleTip={titleTip}
         />
       </div>
     )

--- a/src/intlTelInput.scss
+++ b/src/intlTelInput.scss
@@ -46,8 +46,6 @@ $mobilePopupMargin: 30px;
   // specify types to increase specificity e.g. to override bootstrap v2.3
   input, input[type=text], input[type=tel] {
     position: relative;
-    // input is bottom level, below selected flag and dropdown
-    z-index: 0;
 
     // any vertical margin the user has on their inputs would no longer work as expected
     // because we wrap everything in a container div. i justify the use of !important
@@ -75,11 +73,11 @@ $mobilePopupMargin: 30px;
     right: 0;
     // prevent the highlighted child from overlapping the input border
     padding: $borderWidth;
-  
+
     .arrow {
         font-size: 6px;
         margin-left: 5px;
-        
+
         &.up:after {
             content: '▲';
         }
@@ -92,8 +90,6 @@ $mobilePopupMargin: 30px;
   }
 
   .selected-flag {
-    // render above the input
-    z-index: 1;
     position: relative;
     width: $selectedFlagWidth;
     // this must be full-height both for the hover highlight, and to push down the
@@ -115,7 +111,7 @@ $mobilePopupMargin: 30px;
     list-style: none;
     // in case any container has text-align:center
     text-align: left;
-    
+
     .divider {
         padding-bottom: 5px;
         margin-bottom: 5px;
@@ -184,7 +180,6 @@ $mobilePopupMargin: 30px;
     .flag-container {
       right: auto;
       left: 0;
-      width: 100%;
     }
     .selected-flag {
       width: $selectedFlagArrowWidth;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of using `z-index` that may interfere with other components we can achieve same effect by placing selected flag node after input node.

## Screenshots (if appropriate):
<!--- If possible, please attach the screenshots (you can use recordit.co to record as GIFs) --->
![image](https://user-images.githubusercontent.com/7604250/149341320-5f894c44-1cf8-48d1-8dfe-546f1de61802.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
