### PR TITLE
Update FlagBox.js

### DIFF
--- a/src/components/FlagBox.js
+++ b/src/components/FlagBox.js
@@ -5,9 +5,9 @@ const FlagBox = ({
   dialCode,
   isoCode,
   name,
-  onMouseOver,
-  onFocus,
-  onClick,
+  onMouseOver = () => {},
+  onFocus = () => {},
+  onClick = () => {},
   flagRef,
   innerFlagRef,
   countryClass,
@@ -39,12 +39,6 @@ FlagBox.propTypes = {
   flagRef: PropTypes.func,
   innerFlagRef: PropTypes.func,
   countryClass: PropTypes.string.isRequired,
-}
-
-FlagBox.defaultProps = {
-  onFocus: () => {},
-  onMouseOver: () => {},
-  onClick: () => {},
 }
 
 export default FlagBox


### PR DESCRIPTION
Fixing FlagBox defaultProps for React 18

<!--- Provide a general summary of your changes in the Title above -->

## Description
React 18 issue
after installing with npm install --force

was getting an error in the browser console
Warning: FlagBox: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    at FlagBox (webpack-internal:///(app-pages-browser)/./node_modules/react-intl-tel-input/dist/components/FlagBox.js:13:25)

to fix this I have removed the defaultProps and adjusted the function arguments.

## Screenshots (if appropriate):
<!--- If possible, please attach the screenshots (you can use recordit.co to record as GIFs) --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have used ESLint & Prettier to follow the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
